### PR TITLE
Do not enforce signature algorithm when no templates are used.

### DIFF
--- a/x509util/certificate.go
+++ b/x509util/certificate.go
@@ -52,9 +52,12 @@ func NewCertificate(cr *x509.CertificateRequest, opts ...Option) (*Certificate, 
 	}
 
 	// If no template use only the certificate request with the default leaf key
-	// usages.
+	// usages. And do not enforce signature algorithm from the CSR, it might not
+	// be compatible with the certificate signer.
 	if o.CertBuffer == nil {
-		return newCertificateRequest(cr).GetLeafCertificate(), nil
+		cert := newCertificateRequest(cr).GetLeafCertificate()
+		cert.SignatureAlgorithm = 0
+		return cert, nil
 	}
 
 	// With templates

--- a/x509util/certificate_test.go
+++ b/x509util/certificate_test.go
@@ -140,7 +140,7 @@ func TestNewCertificate(t *testing.T) {
 			Extensions:         newExtensions(cr.Extensions),
 			PublicKey:          priv.Public(),
 			PublicKeyAlgorithm: x509.Ed25519,
-			SignatureAlgorithm: SignatureAlgorithm(x509.PureEd25519),
+			SignatureAlgorithm: SignatureAlgorithm(x509.UnknownSignatureAlgorithm),
 		}, false},
 		{"okDefaultTemplate", args{cr, []Option{WithTemplate(DefaultLeafTemplate, CreateTemplateData("commonName", []string{"foo.com"}))}}, &Certificate{
 			Subject:  Subject{CommonName: "commonName"},


### PR DESCRIPTION
### Description
This PR creates a certificate template without enforcing the CSR signature algorithm when no JSON templates are used.

This was causing step-ca failing to start with RSA keys.