### PR TITLE
Create a new default template for admin provisioners.

### DIFF
--- a/x509util/options_test.go
+++ b/x509util/options_test.go
@@ -112,6 +112,26 @@ func TestWithTemplate(t *testing.T) {
 	"extKeyUsage": ["serverAuth", "clientAuth"]
 }`),
 		}, false},
+		{"admin", args{DefaultAdminLeafTemplate, TemplateData{}, cr}, Options{
+			CertBuffer: bytes.NewBufferString(`{
+	"subject": {"commonName":"foo"},
+	"dnsNames": ["foo.com"],
+	"emailAddresses": ["foo@foo.com"],
+	"ipAddresses": ["::1"],
+	"uris": ["https://foo.com"],
+	"keyUsage": ["digitalSignature"],
+	"extKeyUsage": ["serverAuth", "clientAuth"]
+}`)}, false},
+		{"adminRSA", args{DefaultAdminLeafTemplate, TemplateData{}, crRSA}, Options{
+			CertBuffer: bytes.NewBufferString(`{
+	"subject": {"commonName":"foo"},
+	"dnsNames": ["foo.com"],
+	"emailAddresses": ["foo@foo.com"],
+	"ipAddresses": ["::1"],
+	"uris": ["https://foo.com"],
+	"keyUsage": ["keyEncipherment", "digitalSignature"],
+	"extKeyUsage": ["serverAuth", "clientAuth"]
+}`)}, false},
 		{"fail", args{`{{ fail "a message" }}`, TemplateData{}, cr}, Options{}, true},
 		{"error", args{`{{ mustHas 3 .Data }}`, TemplateData{
 			"Data": 3,

--- a/x509util/templates.go
+++ b/x509util/templates.go
@@ -129,6 +129,23 @@ const DefaultIIDLeafTemplate = `{
 	"extKeyUsage": ["serverAuth", "clientAuth"]
 }`
 
+// DefaultAdminLeafTemplate is a template used by default by K8sSA and
+// admin-OIDC provisioners. This template takes all the SANs and subject from
+// the certificate request.
+const DefaultAdminLeafTemplate = `{
+	"subject": {{ toJson .Insecure.CR.Subject }},
+	"dnsNames": {{ toJson .Insecure.CR.DNSNames }},
+	"emailAddresses": {{ toJson .Insecure.CR.EmailAddresses }},
+	"ipAddresses": {{ toJson .Insecure.CR.IPAddresses }},
+	"uris": {{ toJson .Insecure.CR.URIs }},
+{{- if typeIs "*rsa.PublicKey" .Insecure.CR.PublicKey }}
+	"keyUsage": ["keyEncipherment", "digitalSignature"],
+{{- else }}
+	"keyUsage": ["digitalSignature"],
+{{- end }}
+	"extKeyUsage": ["serverAuth", "clientAuth"]
+}`
+
 // DefaultIntermediateTemplate is a template that can be used to generate an
 // intermediate certificate.
 const DefaultIntermediateTemplate = `{


### PR DESCRIPTION
### Description

This PR adds a new template were only the SANs and subject is read from the CR. The key usage and extended key usages are set in the template.

This template would become the default in k8ssa and admin-OIDC provisioners instead of using `{{ toJson .Insecure.CR }}`