### PR TITLE
tlsutil package

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ to PEM.
 
 Package `randutil` provides methods to generate random strings and salts.
 
+### tlsutil
+
+Package `tlsutil` provides utilities to configure tls client and servers.
+
 ### jose
 
 Package `jose` is a wrapper for `gopkg.in/square/go-jose.v2` and implements

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 	gopkg.in/square/go-jose.v2 v2.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,14 @@ golang.org/x/crypto v0.0.0-20200414173820-0848c9571904 h1:bXoxMPcSLOq08zI3/c5dEB
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e h1:LwyF2AFISC9nVbS6MgzsaQNSUsRXI49GS+YQ5KX/QH0=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -81,7 +81,13 @@ func GenerateKeyPair(kty, crv string, size int) (crypto.PublicKey, crypto.Privat
 	return signer.Public(), signer, nil
 }
 
-// GenerateSigner creates an asymentric crypto key that implements
+// GenerateDefaultSigner returns an asymmetric crypto key that implements
+// crypto.Signer using sane defaults.
+func GenerateDefaultSigner() (crypto.Signer, error) {
+	return GenerateSigner(DefaultKeyType, DefaultKeyCurve, DefaultKeySize)
+}
+
+// GenerateSigner creates an asymmetric crypto key that implements
 // crypto.Signer.
 func GenerateSigner(kty, crv string, size int) (crypto.Signer, error) {
 	switch kty {

--- a/keyutil/key_test.go
+++ b/keyutil/key_test.go
@@ -350,6 +350,35 @@ func TestGenerateKeyPair_rsa(t *testing.T) {
 	}
 }
 
+func TestGenerateDefaultSigner(t *testing.T) {
+	buf := new(bytes.Buffer)
+	setTeeReader(t, buf)
+	ecdsaKey, err := generateECKey("P-256")
+	assert.FatalError(t, err)
+	rand.Reader = buf
+
+	tests := []struct {
+		name    string
+		want    interface{}
+		wantErr bool
+	}{
+		{"ok", ecdsaKey, false},
+		{"eof", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateDefaultSigner()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateDefaultSigner() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GenerateDefaultSigner() = %T, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGenerateSigner(t *testing.T) {
 	buf := new(bytes.Buffer)
 	setTeeReader(t, buf)

--- a/tlsutil/cache.go
+++ b/tlsutil/cache.go
@@ -1,14 +1,12 @@
 package tlsutil
 
 import (
-	"crypto/tls"
 	"sync"
 )
 
 type credentialsCacheElement struct {
-	sni       string
-	renewer   *Renewer
-	tlsConfig *tls.Config
+	sni     string
+	renewer *Renewer
 }
 
 type credentialsCache struct {

--- a/tlsutil/cache.go
+++ b/tlsutil/cache.go
@@ -1,0 +1,50 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+type credentialsCacheElement struct {
+	sni       string
+	renewer   *Renewer
+	tlsConfig *tls.Config
+}
+
+type credentialsCache struct {
+	CacheStore *sync.Map
+}
+
+func newCredentialsCache() *credentialsCache {
+	return &credentialsCache{
+		CacheStore: new(sync.Map),
+	}
+}
+
+func (c *credentialsCache) Load(domain string) (*credentialsCacheElement, bool) {
+	v, ok := c.CacheStore.Load(domain)
+	if !ok {
+		return nil, false
+	}
+	e, ok := v.(*credentialsCacheElement)
+	return e, ok
+}
+
+func (c *credentialsCache) Store(domain string, v *credentialsCacheElement) {
+	c.CacheStore.Store(domain, v)
+}
+
+func (c *credentialsCache) Delete(domain string) {
+	c.CacheStore.Delete(domain)
+}
+
+func (c *credentialsCache) Range(fn func(domain string, v *credentialsCacheElement) bool) {
+	c.CacheStore.Range(func(k, v interface{}) bool {
+		if domain, ok := k.(string); ok {
+			if e, ok := v.(*credentialsCacheElement); ok {
+				return fn(domain, e)
+			}
+		}
+		return true
+	})
+}

--- a/tlsutil/cache_test.go
+++ b/tlsutil/cache_test.go
@@ -1,0 +1,171 @@
+package tlsutil
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func testCache() *sync.Map {
+	m := new(sync.Map)
+	m.Store("ok.test", &credentialsCacheElement{
+		sni: "ok.test",
+	})
+	m.Store("bad.test", 123)
+	m.Store("nil.test", nil)
+	return m
+}
+
+func Test_newCredentialsCache(t *testing.T) {
+	tests := []struct {
+		name string
+		want *credentialsCache
+	}{
+		{"ok", &credentialsCache{
+			CacheStore: new(sync.Map),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newCredentialsCache(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newCredentialsCache() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_credentialsCache_Load(t *testing.T) {
+	m := testCache()
+	type fields struct {
+		CacheStore *sync.Map
+	}
+	type args struct {
+		domain string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *credentialsCacheElement
+		want1  bool
+	}{
+		{"ok", fields{m}, args{"ok.test"}, &credentialsCacheElement{sni: "ok.test"}, true},
+		{"nil", fields{m}, args{"nil.test"}, nil, false},
+		{"fail", fields{m}, args{"fail.test"}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &credentialsCache{
+				CacheStore: tt.fields.CacheStore,
+			}
+			got, got1 := c.Load(tt.args.domain)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("credentialsCache.Load() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("credentialsCache.Load() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_credentialsCache_Store(t *testing.T) {
+	type fields struct {
+		CacheStore *sync.Map
+	}
+	type args struct {
+		domain string
+		v      *credentialsCacheElement
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{"ok", fields{new(sync.Map)}, args{"ok.test", &credentialsCacheElement{sni: "ok.test"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &credentialsCache{
+				CacheStore: tt.fields.CacheStore,
+			}
+			c.Store(tt.args.domain, tt.args.v)
+
+			got, got1 := c.Load(tt.args.domain)
+			if !reflect.DeepEqual(got, tt.args.v) {
+				t.Errorf("credentialsCache.Load() got = %v, want %v", got, tt.args.v)
+			}
+			if !got1 {
+				t.Errorf("credentialsCache.Load() got1 = %v, want %v", got1, true)
+			}
+		})
+	}
+}
+
+func Test_credentialsCache_Delete(t *testing.T) {
+	m := testCache()
+	type fields struct {
+		CacheStore *sync.Map
+	}
+	type args struct {
+		domain string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{"ok", fields{m}, args{"ok.test"}},
+		{"deleted", fields{m}, args{"ok.test"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &credentialsCache{
+				CacheStore: tt.fields.CacheStore,
+			}
+			c.Delete(tt.args.domain)
+
+			got, got1 := c.Load(tt.args.domain)
+			if !reflect.DeepEqual(got, (*credentialsCacheElement)(nil)) {
+				t.Errorf("credentialsCache.Load() got = %v, want %v", got, nil)
+			}
+			if got1 {
+				t.Errorf("credentialsCache.Load() got1 = %v, want %v", got1, false)
+			}
+		})
+	}
+}
+
+func Test_credentialsCache_Range(t *testing.T) {
+	got := []*credentialsCacheElement{}
+	want := []*credentialsCacheElement{
+		&credentialsCacheElement{sni: "ok.test"},
+	}
+	type fields struct {
+		CacheStore *sync.Map
+	}
+	type args struct {
+		fn func(domain string, v *credentialsCacheElement) bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{"ok", fields{testCache()}, args{func(domain string, v *credentialsCacheElement) bool {
+			got = append(got, v)
+			return true
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &credentialsCache{
+				CacheStore: tt.fields.CacheStore,
+			}
+			c.Range(tt.args.fn)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("credentialsCache.Range() got = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/tlsutil/renewer.go
+++ b/tlsutil/renewer.go
@@ -1,0 +1,192 @@
+package tlsutil
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// RenewFunc defines the type of the functions used to get a new tls
+// certificate.
+type RenewFunc func() (*tls.Certificate, *tls.Config, error)
+
+// MinCertDuration is the minimum validity of a certificate.
+var MinCertDuration = time.Minute
+
+// Renewer automatically renews a tls certificate using a RenewFunc.
+type Renewer struct {
+	sync.RWMutex
+	RenewFunc    RenewFunc
+	cert         *tls.Certificate
+	config       *tls.Config
+	timer        *time.Timer
+	renewBefore  time.Duration
+	renewJitter  time.Duration
+	certNotAfter time.Time
+}
+
+type renewerOptions func(r *Renewer) error
+
+// WithRenewBefore modifies a tls renewer by setting the renewBefore attribute.
+func WithRenewBefore(b time.Duration) func(r *Renewer) error {
+	return func(r *Renewer) error {
+		r.renewBefore = b
+		return nil
+	}
+}
+
+// WithRenewJitter modifies a tls renewer by setting the renewJitter attribute.
+func WithRenewJitter(j time.Duration) func(r *Renewer) error {
+	return func(r *Renewer) error {
+		r.renewJitter = j
+		return nil
+	}
+}
+
+// NewRenewer creates a TLS renewer for the given cert. It will use the given
+// RenewFunc to get a new certificate when required.
+func NewRenewer(cert *tls.Certificate, config *tls.Config, fn RenewFunc, opts ...renewerOptions) (*Renewer, error) {
+	r := &Renewer{
+		RenewFunc:    fn,
+		cert:         cert,
+		config:       config,
+		certNotAfter: cert.Leaf.NotAfter,
+	}
+
+	for _, f := range opts {
+		if err := f(r); err != nil {
+			return nil, fmt.Errorf("error applying options: %w", err)
+		}
+	}
+
+	period := cert.Leaf.NotAfter.Sub(cert.Leaf.NotBefore)
+	if period < MinCertDuration {
+		return nil, fmt.Errorf("period must be greater than or equal to %s, but got %v", MinCertDuration, period)
+	}
+	// By default we will try to renew the cert before 2/3 of the validity
+	// period have expired.
+	if r.renewBefore == 0 {
+		r.renewBefore = period / 3
+	}
+	// By default we set the jitter to 1/20th of the validity period.
+	if r.renewJitter == 0 {
+		r.renewJitter = period / 20
+	}
+
+	return r, nil
+}
+
+// Run starts the certificate renewer for the given certificate.
+func (r *Renewer) Run() {
+	r.Lock()
+	next := r.nextRenewDuration(r.certNotAfter)
+	r.timer = time.AfterFunc(next, r.renewCertificate)
+	r.Unlock()
+}
+
+// RunContext starts the certificate renewer for the given certificate.
+func (r *Renewer) RunContext(ctx context.Context) {
+	r.Run()
+	go func() {
+		<-ctx.Done()
+		r.Stop()
+	}()
+}
+
+// Stop prevents the renew timer from firing.
+func (r *Renewer) Stop() bool {
+	if r.timer != nil {
+		return r.timer.Stop()
+	}
+	return true
+}
+
+// GetCertificate returns the current server certificate.
+//
+// This method is set in the tls.Config GetCertificate property.
+func (r *Renewer) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return r.getCertificate(), nil
+}
+
+// GetClientCertificate returns the current client certificate.
+//
+// This method is set in the tls.Config GetClientCertificate property.
+func (r *Renewer) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return r.getCertificate(), nil
+}
+
+// GetConfigForClient returns the tls.Config used per request.
+//
+// This method is set in the tls.Config GetConfigForClient property.
+func (r *Renewer) GetConfigForClient(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+	return r.getConfigForClient(), nil
+}
+
+// getCertificate returns the certificate using a read-only lock. It will
+// automatically renew the certificate if it has expired.
+func (r *Renewer) getCertificate() *tls.Certificate {
+	r.RLock()
+	// Force certificate renewal if the timer didn't run.
+	// This is an special case that can happen after a computer sleep.
+	if time.Now().After(r.certNotAfter) {
+		r.RUnlock()
+		r.renewCertificate()
+		r.RLock()
+	}
+	cert := r.cert
+	r.RUnlock()
+	return cert
+}
+
+func (r *Renewer) getConfigForClient() *tls.Config {
+	r.RLock()
+	// Force certificate renewal if the timer didn't run.
+	// This is an special case that can happen after a computer sleep.
+	if time.Now().After(r.certNotAfter) {
+		r.RUnlock()
+		r.renewCertificate()
+		r.RLock()
+	}
+	config := r.config
+	r.RUnlock()
+	return config
+}
+
+// setCertificate updates the certificate using a read-write lock. It also
+// updates certNotAfter with 1m of delta; this will force the renewal of the
+// certificate if it is about to expire.
+func (r *Renewer) setCertificate(cert *tls.Certificate, config *tls.Config) {
+	r.Lock()
+	r.cert = cert
+	r.config = config
+	r.certNotAfter = cert.Leaf.NotAfter
+	r.Unlock()
+}
+
+func (r *Renewer) renewCertificate() {
+	var next time.Duration
+	cert, config, err := r.RenewFunc()
+	if err != nil {
+		next = r.renewJitter / 2
+		next += time.Duration(rand.Int63n(int64(next)))
+	} else {
+		r.setCertificate(cert, config)
+		next = r.nextRenewDuration(cert.Leaf.NotAfter)
+	}
+	r.Lock()
+	r.timer.Reset(next)
+	r.Unlock()
+}
+
+func (r *Renewer) nextRenewDuration(notAfter time.Time) time.Duration {
+	d := time.Until(notAfter) - r.renewBefore
+	n := rand.Int63n(int64(r.renewJitter))
+	d -= time.Duration(n)
+	if d < 0 {
+		d = 0
+	}
+	return d
+}

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -175,7 +175,7 @@ func TestNewRenewer(t *testing.T) {
 				tt.want.RenewFunc = nil
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewRenewer() = %v, want %v", got, tt.want)
+				t.Errorf("NewRenewer() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"reflect"
 	"testing"
@@ -107,6 +109,20 @@ func testRenewFunc() (*tls.Certificate, *tls.Config, error) {
 		PrivateKey:  leafKey,
 		Leaf:        leafCert,
 	}, tlsConfig, nil
+}
+
+func getLocalHostURL(t *testing.T, rawurl string) string {
+	t.Helper()
+
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, p, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "https://" + net.JoinHostPort("localhost", p)
 }
 
 func TestNewRenewer(t *testing.T) {
@@ -381,6 +397,124 @@ func TestRenewer_GetClientCertificate(t *testing.T) {
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("http.Client.Get() = %v, want %v", got, tt.want)
 				}
+			}
+		})
+	}
+}
+
+func TestRenewer_RenewFunc_error(t *testing.T) {
+	// Create exprired cert
+	leafCsr, err := x509util.CreateCertificateRequest("Leaf", []string{"127.0.0.1", "localhost"}, leafKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509util.NewCertificate(leafCsr,
+		x509util.WithTemplate(x509util.DefaultLeafTemplate, x509util.CreateTemplateData("Leaf", []string{"127.0.0.1", "localhost"})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := cert.GetCertificate()
+	template.NotBefore = time.Now()
+	template.NotAfter = time.Now()
+	template.SerialNumber = big.NewInt(1)
+	leaf, err := x509util.CreateCertificate(template, issuerCert, leafKey.Public(), issuerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiredCert := &tls.Certificate{
+		Certificate: [][]byte{leaf.Raw},
+		PrivateKey:  leafKey,
+		Leaf:        leaf,
+	}
+
+	// Prepare server
+	r, err := NewRenewer(tlsCert, tlsConfig, func() (*tls.Certificate, *tls.Config, error) {
+		return nil, nil, fmt.Errorf("test error")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Run()
+	defer r.Stop()
+
+	// Mark certificate as expired
+	r.Lock()
+	r.cert = expiredCert
+	r.certNotAfter = expiredCert.Leaf.NotAfter
+	r.Unlock()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(issuerCert)
+
+	tests := []struct {
+		name         string
+		serverConfig *tls.Config
+		clientConfig *tls.Config
+	}{
+		{"fail GetCertificate", &tls.Config{
+			GetCertificate: r.GetCertificate,
+			ClientAuth:     tls.RequireAndVerifyClientCert,
+			ClientCAs:      pool,
+		}, &tls.Config{
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return tlsCert, nil
+			},
+			RootCAs: pool,
+		}},
+		{"fail GetConfigForClient", &tls.Config{
+			GetConfigForClient: r.GetConfigForClient,
+			ClientAuth:         tls.RequireAndVerifyClientCert,
+			ClientCAs:          pool,
+		}, &tls.Config{
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return tlsCert, nil
+			},
+			RootCAs: pool,
+		}},
+		{"fail GetClientCertificate", &tls.Config{
+			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return tlsCert, nil
+			},
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  pool,
+		}, &tls.Config{
+			GetClientCertificate: r.GetClientCertificate,
+			RootCAs:              pool,
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				// 	t.Error("missing peer certificate")
+				// }
+				fmt.Fprintf(w, "ok")
+			}))
+			srv.TLS = tt.serverConfig
+			srv.StartTLS()
+			// We need to set Certificates to nil, because if the hello message does not
+			// have a SNI, this certificate will be used.
+			srv.TLS.Certificates = nil
+			defer srv.Close()
+
+			// Create url with localhost
+			dnsURL := getLocalHostURL(t, srv.URL)
+
+			tr := http.DefaultTransport.(*http.Transport).Clone()
+			tr.TLSClientConfig = tt.clientConfig
+			tr.TLSClientConfig = &tls.Config{
+				GetClientCertificate: r.GetClientCertificate,
+				RootCAs:              pool,
+			}
+
+			trNoCert := http.DefaultTransport.(*http.Transport).Clone()
+			trNoCert.TLSClientConfig = &tls.Config{
+				RootCAs: pool,
+			}
+			c := &http.Client{Transport: tr}
+			if _, err := c.Get(dnsURL); err == nil {
+				t.Errorf("http.Client.Get() error = %v, wantErr true", err)
 			}
 		})
 	}

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -193,7 +193,7 @@ func TestRenewer_Run(t *testing.T) {
 		t.Fatal(err)
 	}
 	r.renewJitter = 1
-	r.renewBefore = tlsCert.Leaf.NotAfter.Sub(time.Now()) - time.Second
+	r.renewBefore = time.Until(tlsCert.Leaf.NotAfter) - time.Second
 
 	r.Run()
 	defer r.Stop()
@@ -218,7 +218,7 @@ func TestRenewer_RunContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	r.renewJitter = 1
-	r.renewBefore = tlsCert.Leaf.NotAfter.Sub(time.Now()) - time.Second
+	r.renewBefore = time.Until(tlsCert.Leaf.NotAfter) - time.Second
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -1,0 +1,387 @@
+package tlsutil
+
+import (
+	"context"
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.step.sm/crypto/keyutil"
+	"go.step.sm/crypto/x509util"
+)
+
+var (
+	issuerCert *x509.Certificate
+	issuerKey  crypto.Signer
+	leafCert   *x509.Certificate
+	leafKey    crypto.Signer
+	tlsCert    *tls.Certificate
+	tlsConfig  *tls.Config
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	// Create Issuer
+	issuerKey, err = keyutil.GenerateDefaultSigner()
+	if err != nil {
+		panic(err)
+	}
+	issuerCsr, err := x509util.CreateCertificateRequest("RootCA", []string{}, issuerKey)
+	if err != nil {
+		panic(err)
+	}
+	cert, err := x509util.NewCertificate(issuerCsr,
+		x509util.WithTemplate(x509util.DefaultRootTemplate, x509util.CreateTemplateData("RootCA", []string{})))
+	if err != nil {
+		panic(err)
+	}
+	parent := cert.GetCertificate()
+	parent.NotBefore = time.Now()
+	parent.NotAfter = parent.NotBefore.Add(time.Hour)
+	issuerCert, err = x509util.CreateCertificate(parent, parent, issuerKey.Public(), issuerKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create Leaf
+	leafKey, err = keyutil.GenerateDefaultSigner()
+	if err != nil {
+		panic(err)
+	}
+	leafCsr, err := x509util.CreateCertificateRequest("Leaf", []string{"127.0.0.1", "localhost"}, leafKey)
+	if err != nil {
+		panic(err)
+	}
+	cert, err = x509util.NewCertificate(leafCsr,
+		x509util.WithTemplate(x509util.DefaultLeafTemplate, x509util.CreateTemplateData("Leaf", []string{"127.0.0.1", "localhost"})))
+	if err != nil {
+		panic(err)
+	}
+	template := cert.GetCertificate()
+	template.NotBefore = time.Now()
+	template.NotAfter = template.NotBefore.Add(time.Hour)
+	template.SerialNumber = big.NewInt(1)
+	leafCert, err = x509util.CreateCertificate(template, issuerCert, leafKey.Public(), issuerKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create tls cert and config
+	pool := x509.NewCertPool()
+	pool.AddCert(issuerCert)
+	tlsCert = &tls.Certificate{
+		Certificate: [][]byte{leafCert.Raw},
+		PrivateKey:  leafKey,
+		Leaf:        leafCert,
+	}
+	tlsConfig = &tls.Config{
+		RootCAs:    pool,
+		ClientCAs:  pool,
+		ClientAuth: tls.VerifyClientCertIfGiven,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	os.Exit(m.Run())
+}
+
+func testRenewFunc() (*tls.Certificate, *tls.Config, error) {
+	var err error
+	leafCert.NotBefore = time.Now()
+	leafCert.NotAfter = leafCert.NotBefore.Add(time.Hour)
+	leafCert.SerialNumber = leafCert.SerialNumber.Add(leafCert.SerialNumber, big.NewInt(1))
+	leafCert, err = x509util.CreateCertificate(leafCert, issuerCert, leafKey.Public(), issuerKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{leafCert.Raw},
+		PrivateKey:  leafKey,
+		Leaf:        leafCert,
+	}, tlsConfig, nil
+}
+
+func TestNewRenewer(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		cert   *tls.Certificate
+		config *tls.Config
+		fn     RenewFunc
+		opts   []renewerOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Renewer
+		wantErr bool
+	}{
+		{"ok", args{tlsCert, tlsConfig, testRenewFunc, nil}, &Renewer{
+			RenewFunc:    testRenewFunc,
+			cert:         tlsCert,
+			config:       tlsConfig,
+			renewBefore:  time.Hour / 3,
+			renewJitter:  time.Hour / 20,
+			certNotAfter: leafCert.NotAfter,
+		}, false},
+		{"WithRenewBefore", args{tlsCert, tlsConfig, testRenewFunc, []renewerOptions{WithRenewBefore(time.Minute)}}, &Renewer{
+			RenewFunc:    testRenewFunc,
+			cert:         tlsCert,
+			config:       tlsConfig,
+			renewBefore:  time.Minute,
+			renewJitter:  time.Hour / 20,
+			certNotAfter: leafCert.NotAfter,
+		}, false},
+		{"WithRenewJitter", args{tlsCert, tlsConfig, testRenewFunc, []renewerOptions{WithRenewJitter(time.Minute)}}, &Renewer{
+			RenewFunc:    testRenewFunc,
+			cert:         tlsCert,
+			config:       tlsConfig,
+			renewBefore:  time.Hour / 3,
+			renewJitter:  time.Minute,
+			certNotAfter: leafCert.NotAfter,
+		}, false},
+		{"fail", args{&tls.Certificate{
+			Certificate: [][]byte{leafCert.Raw},
+			PrivateKey:  leafKey,
+			Leaf: &x509.Certificate{
+				NotBefore: now,
+				NotAfter:  now.Add(MinCertDuration - time.Nanosecond),
+			},
+		}, tlsConfig, testRenewFunc, []renewerOptions{WithRenewJitter(time.Minute)}}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRenewer(tt.args.cert, tt.args.config, tt.args.fn, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRenewer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Cannot deep equal methods
+			if got != nil {
+				got.RenewFunc = nil
+				got.config.GetCertificate = nil
+				got.config.GetClientCertificate = nil
+				got.config.GetConfigForClient = nil
+			}
+			if tt.want != nil {
+				tt.want.RenewFunc = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewRenewer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenewer_Run(t *testing.T) {
+	i := 0
+	fn := func() (*tls.Certificate, *tls.Config, error) {
+		i++
+		return testRenewFunc()
+	}
+
+	r, err := NewRenewer(tlsCert, tlsConfig, fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.renewJitter = 1
+	r.renewBefore = tlsCert.Leaf.NotAfter.Sub(time.Now()) - time.Second
+
+	r.Run()
+	defer r.Stop()
+
+	time.Sleep(2 * time.Second)
+	if i == 0 {
+		t.Errorf("Renewer.Run() timer didn't run")
+	} else {
+		t.Logf("Renewer.Run() run %d times", i)
+	}
+}
+
+func TestRenewer_RunContext(t *testing.T) {
+	i := 0
+	fn := func() (*tls.Certificate, *tls.Config, error) {
+		i++
+		return testRenewFunc()
+	}
+
+	r, err := NewRenewer(tlsCert, tlsConfig, fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.renewJitter = 1
+	r.renewBefore = tlsCert.Leaf.NotAfter.Sub(time.Now()) - time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r.RunContext(ctx)
+
+	time.Sleep(2 * time.Second)
+	if i == 0 {
+		t.Errorf("Renewer.RunContext() timer didn't run")
+	} else {
+		t.Logf("Renewer.RunContext() run %d times", i)
+	}
+}
+
+func TestRenewer_Stop(t *testing.T) {
+	type fields struct {
+		timer *time.Timer
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"ok", fields{time.AfterFunc(time.Second, func() {})}, true},
+		{"ok nil", fields{nil}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Renewer{
+				timer: tt.fields.timer,
+			}
+			if got := r.Stop(); got != tt.want {
+				t.Errorf("Renewer.Stop() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenewer_GetCertificate(t *testing.T) {
+	// Prepare server
+	r, err := NewRenewer(tlsCert, tlsConfig, testRenewFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Run()
+	defer r.Stop()
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "ok")
+	}))
+	srv.TLS = r.GetConfig()
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Prepare valid client
+	pool := x509.NewCertPool()
+	pool.AddCert(issuerCert)
+
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{
+		RootCAs: pool,
+	}
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		want    []byte
+		wantErr bool
+	}{
+		{"ok", &http.Client{Transport: tr}, []byte("ok"), false},
+		{"fail empty", &http.Client{}, nil, true},
+		{"fail httptest", srv.Client(), nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.client.Get(srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("http.Client.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if resp != nil && resp.Body != nil {
+				got, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("ioutil.ReadAll() error = %v", err)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("http.Client.Get() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestRenewer_GetClientCertificate(t *testing.T) {
+	// Prepare server
+	r, err := NewRenewer(tlsCert, tlsConfig, testRenewFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Run()
+	defer r.Stop()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(issuerCert)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			t.Error("missing peer certificate")
+		}
+		fmt.Fprintf(w, "ok")
+	}))
+	srv.TLS = &tls.Config{
+		GetCertificate: r.GetCertificate,
+		ClientCAs:      pool,
+		ClientAuth:     tls.RequireAndVerifyClientCert,
+	}
+	srv.StartTLS()
+	// We need to set Certificates to nil, because if the hello message does not
+	// have a SNI, this certificate will be used.
+	srv.TLS.Certificates = nil
+	defer srv.Close()
+
+	// Prepare valid client
+
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{
+		GetClientCertificate: r.GetClientCertificate,
+		RootCAs:              pool,
+	}
+
+	trNoCert := http.DefaultTransport.(*http.Transport).Clone()
+	trNoCert.TLSClientConfig = &tls.Config{
+		RootCAs: pool,
+	}
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		want    []byte
+		wantErr bool
+	}{
+		{"ok", &http.Client{Transport: tr}, []byte("ok"), false},
+		{"fail no cert", &http.Client{Transport: trNoCert}, nil, true},
+		{"fail empty", &http.Client{}, nil, true},
+		{"fail httptest", srv.Client(), nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.client.Get(srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("http.Client.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if resp != nil && resp.Body != nil {
+				got, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("ioutil.ReadAll() error = %v", err)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("http.Client.Get() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -175,7 +175,8 @@ func TestNewRenewer(t *testing.T) {
 				tt.want.RenewFunc = nil
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewRenewer() = %#v, want %#v", got, tt.want)
+				t.Errorf("NewRenewer() = %v, want %v", got, tt.want)
+				t.Errorf("NewRenewer() = %#v, want %#v", got.config, tt.want.config)
 			}
 		})
 	}

--- a/tlsutil/renewer_test.go
+++ b/tlsutil/renewer_test.go
@@ -126,7 +126,7 @@ func TestNewRenewer(t *testing.T) {
 		{"ok", args{tlsCert, tlsConfig, testRenewFunc, nil}, &Renewer{
 			RenewFunc:    testRenewFunc,
 			cert:         tlsCert,
-			config:       tlsConfig,
+			config:       tlsConfig.Clone(),
 			renewBefore:  time.Hour / 3,
 			renewJitter:  time.Hour / 20,
 			certNotAfter: leafCert.NotAfter,
@@ -134,7 +134,7 @@ func TestNewRenewer(t *testing.T) {
 		{"WithRenewBefore", args{tlsCert, tlsConfig, testRenewFunc, []renewerOptions{WithRenewBefore(time.Minute)}}, &Renewer{
 			RenewFunc:    testRenewFunc,
 			cert:         tlsCert,
-			config:       tlsConfig,
+			config:       tlsConfig.Clone(),
 			renewBefore:  time.Minute,
 			renewJitter:  time.Hour / 20,
 			certNotAfter: leafCert.NotAfter,
@@ -142,7 +142,7 @@ func TestNewRenewer(t *testing.T) {
 		{"WithRenewJitter", args{tlsCert, tlsConfig, testRenewFunc, []renewerOptions{WithRenewJitter(time.Minute)}}, &Renewer{
 			RenewFunc:    testRenewFunc,
 			cert:         tlsCert,
-			config:       tlsConfig,
+			config:       tlsConfig.Clone(),
 			renewBefore:  time.Hour / 3,
 			renewJitter:  time.Minute,
 			certNotAfter: leafCert.NotAfter,
@@ -176,7 +176,6 @@ func TestNewRenewer(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewRenewer() = %v, want %v", got, tt.want)
-				t.Errorf("NewRenewer() = %#v, want %#v", got.config, tt.want.config)
 			}
 		})
 	}

--- a/tlsutil/server_credentials.go
+++ b/tlsutil/server_credentials.go
@@ -60,7 +60,7 @@ func (c *ServerCredentials) GetConfigForClient(hello *tls.ClientHelloInfo) (*tls
 	}
 
 	if v, ok := c.cache.Load(sni); ok {
-		return v.tlsConfig, nil
+		return v.renewer.GetConfigForClient(hello)
 	}
 
 	renewer, err := c.getCertificate(sni, hello)
@@ -86,9 +86,8 @@ func (c *ServerCredentials) getCertificate(sni string, hello *tls.ClientHelloInf
 	renewer.Run()
 
 	c.cache.Store(sni, &credentialsCacheElement{
-		sni:       sni,
-		renewer:   renewer,
-		tlsConfig: tlsConfig,
+		sni:     sni,
+		renewer: renewer,
 	})
 
 	return renewer, nil

--- a/tlsutil/server_credentials.go
+++ b/tlsutil/server_credentials.go
@@ -1,0 +1,95 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// ServerRenewFunc defines the type of the functions used to get a new tls
+// certificate.
+type ServerRenewFunc func(hello *tls.ClientHelloInfo) (*tls.Certificate, *tls.Config, error)
+
+// ServerCredentials is a type that manages the credentials of a server.
+type ServerCredentials struct {
+	RenewFunc ServerRenewFunc
+	cache     *credentialsCache
+}
+
+// NewServerCredentials returns a new ServerCredentials that will get
+// certificates from the given function.
+func NewServerCredentials(fn ServerRenewFunc) (*ServerCredentials, error) {
+	return &ServerCredentials{
+		RenewFunc: fn,
+		cache:     newCredentialsCache(),
+	}, nil
+}
+
+// GetCertificate returns the certificate for the SNI in the hello message.
+func (c *ServerCredentials) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if hello.ServerName == "" {
+		return nil, fmt.Errorf("server name indication cannot be empty")
+	}
+
+	sni, err := SanitizeName(hello.ServerName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to load a certificate.
+	if v, ok := c.cache.Load(sni); ok {
+		return v.renewer.GetCertificate(hello)
+	}
+
+	renewer, err := c.getCertificate(sni, hello)
+	if err != nil {
+		return nil, err
+	}
+
+	return renewer.GetCertificate(hello)
+}
+
+// GetConfigForClient returns the tls.Config used per request.
+func (c *ServerCredentials) GetConfigForClient(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+	if hello.ServerName == "" {
+		return nil, fmt.Errorf("server name indication cannot be empty")
+	}
+
+	sni, err := SanitizeName(hello.ServerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if v, ok := c.cache.Load(sni); ok {
+		return v.tlsConfig, nil
+	}
+
+	renewer, err := c.getCertificate(sni, hello)
+	if err != nil {
+		return nil, err
+	}
+
+	return renewer.GetConfigForClient(hello)
+}
+
+func (c *ServerCredentials) getCertificate(sni string, hello *tls.ClientHelloInfo) (*Renewer, error) {
+	cert, tlsConfig, err := c.RenewFunc(hello)
+	if err != nil {
+		return nil, err
+	}
+
+	renewer, err := NewRenewer(cert, tlsConfig, func() (*tls.Certificate, *tls.Config, error) {
+		return c.RenewFunc(hello)
+	})
+	if err != nil {
+		return nil, err
+	}
+	renewer.Run()
+
+	c.cache.Store(sni, &credentialsCacheElement{
+		sni:       sni,
+		renewer:   renewer,
+		tlsConfig: tlsConfig,
+	})
+
+	return renewer, nil
+}

--- a/tlsutil/utils.go
+++ b/tlsutil/utils.go
@@ -1,0 +1,38 @@
+package tlsutil
+
+import (
+	"errors"
+	"net"
+
+	"golang.org/x/net/idna"
+)
+
+// SanitizeName converts the given domain to its ASCII form.
+func SanitizeName(domain string) (string, error) {
+	if domain == "" {
+		return "", errors.New("empty server name")
+	}
+
+	// Note that this conversion is necessary because some server names in the handshakes
+	// started by some clients (such as cURL) are not converted to Punycode, which will
+	// prevent us from obtaining certificates for them. In addition, we should also treat
+	// example.com and EXAMPLE.COM as equivalent and return the same certificate for them.
+	// Fortunately, this conversion also helped us deal with this kind of mixedcase problems.
+	//
+	// Due to the "σςΣ" problem (see https://unicode.org/faq/idn.html#22), we can't use
+	// idna.Punycode.ToASCII (or just idna.ToASCII) here.
+	name, err := idna.Lookup.ToASCII(domain)
+	if err != nil {
+		return "", errors.New("server name contains invalid character")
+	}
+
+	return name, nil
+}
+
+// SanitizeHost returns the ASCII form of the host part in a host:port address.
+func SanitizeHost(host string) (string, error) {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return SanitizeName(h)
+	}
+	return SanitizeName(host)
+}

--- a/tlsutil/utils_test.go
+++ b/tlsutil/utils_test.go
@@ -1,0 +1,64 @@
+package tlsutil
+
+import (
+	"testing"
+)
+
+func TestSanitizeName(t *testing.T) {
+	type args struct {
+		domain string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"ok", args{"smallstep.com"}, "smallstep.com", false},
+		{"ok ascii", args{"bücher.example.com"}, "xn--bcher-kva.example.com", false},
+		{"fail", args{"xn--bücher.example.com"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeName(tt.args.domain)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SanitizeName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SanitizeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeHost(t *testing.T) {
+	type args struct {
+		host string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"ok", args{"smallstep.com"}, "smallstep.com", false},
+		{"ok port", args{"smallstep.com:443"}, "smallstep.com", false},
+		{"ok ascii", args{"bücher.example.com"}, "xn--bcher-kva.example.com", false},
+		{"ok ascii port", args{"bücher.example.com:443"}, "xn--bcher-kva.example.com", false},
+		{"fail", args{"xn--bücher.example.com"}, "", true},
+		{"fail port", args{"xn--bücher.example.com:443"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeHost(tt.args.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SanitizeHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SanitizeHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tlsutil/utils_test.go
+++ b/tlsutil/utils_test.go
@@ -17,6 +17,7 @@ func TestSanitizeName(t *testing.T) {
 		{"ok", args{"smallstep.com"}, "smallstep.com", false},
 		{"ok ascii", args{"bücher.example.com"}, "xn--bcher-kva.example.com", false},
 		{"fail", args{"xn--bücher.example.com"}, "", true},
+		{"fail empty", args{""}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +49,8 @@ func TestSanitizeHost(t *testing.T) {
 		{"ok ascii port", args{"bücher.example.com:443"}, "xn--bcher-kva.example.com", false},
 		{"fail", args{"xn--bücher.example.com"}, "", true},
 		{"fail port", args{"xn--bücher.example.com:443"}, "", true},
+		{"fail empty", args{""}, "", true},
+		{"fail empty with port", args{":443"}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description

This PR adds a new package including a refined version of the ca.Renewer in https://github.com/smallstep/certificates, as well as a ServerCredentials type that is a renewer for servers. The main difference is that the renew function can return different credentials depending on the SNI.