### PR TITLE
Incorrect password

### DIFF
--- a/pemutil/cosign.go
+++ b/pemutil/cosign.go
@@ -34,6 +34,8 @@ type cosignCipher struct {
 }
 
 // ParseCosignPrivateKey returns the private key encoded using cosign envelope.
+// If an incorrect password is detected an x509.IncorrectPasswordError is
+// returned.
 //
 // Cosign keys are encrypted under a password using scrypt as a KDF and
 // nacl/secretbox for encryption.
@@ -65,7 +67,7 @@ func ParseCosignPrivateKey(data []byte, password []byte) (crypto.PrivateKey, err
 
 	out, ok := secretbox.Open(nil, env.Ciphertext, &nonce, &key)
 	if !ok {
-		return nil, errors.New("error opening secretbox: invalid key")
+		return nil, x509.IncorrectPasswordError
 	}
 
 	priv, err := x509.ParsePKCS8PrivateKey(out)

--- a/pemutil/cosign_test.go
+++ b/pemutil/cosign_test.go
@@ -188,3 +188,24 @@ func TestParseCosignPrivateKey_equal(t *testing.T) {
 		t.Errorf("Public keys do not match() = %v, want %v", pub, key.(crypto.Signer).Public())
 	}
 }
+
+func TestParseCosignPrivateKey_IncorrectPasswordError(t *testing.T) {
+	b, err := ioutil.ReadFile("testdata/cosign.enc.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(b)
+	if block == nil {
+		t.Fatal("error decoding testdata/cosign.enc.pem")
+	}
+
+	_, err = ParseCosignPrivateKey(block.Bytes, []byte("mypassword"))
+	if err != nil {
+		t.Errorf("ParseCosignPrivateKey() error = %v", err)
+	}
+
+	_, err = ParseCosignPrivateKey(block.Bytes, []byte("foobar"))
+	if err != x509.IncorrectPasswordError {
+		t.Errorf("ParseCosignPrivateKey() error = %v, wantErr = %v", err, x509.IncorrectPasswordError)
+	}
+}

--- a/pemutil/pem_test.go
+++ b/pemutil/pem_test.go
@@ -677,10 +677,6 @@ func TestSerialize(t *testing.T) {
 						assert.Equals(t, p.Type, "ENCRYPTED PRIVATE KEY")
 						actualBytes, err = DecryptPKCS8PrivateKey(p.Bytes, []byte(test.pass))
 						assert.FatalError(t, err)
-						// remove padding
-						length := len(actualBytes)
-						paddginLength := int(actualBytes[length-1])
-						actualBytes = actualBytes[:length-paddginLength]
 					} else {
 						assert.Equals(t, p.Type, "EC PRIVATE KEY")
 						assert.True(t, x509.IsEncryptedPEMBlock(p))

--- a/pemutil/pem_test.go
+++ b/pemutil/pem_test.go
@@ -486,7 +486,7 @@ func TestParse(t *testing.T) {
 				in:      b,
 				opts:    []Options{WithPassword([]byte("badpassword"))},
 				cmpType: ed25519.PrivateKey{},
-				err:     errors.New("error parsing PEM"),
+				err:     errors.New("error decrypting PEM: x509: decryption password incorrect"),
 			}
 		},
 		"fail-type": func(t *testing.T) *ParseTest {

--- a/pemutil/pkcs8.go
+++ b/pemutil/pkcs8.go
@@ -274,7 +274,7 @@ func DecryptPKCS8PrivateKey(data, password []byte) ([]byte, error) {
 		}
 	}
 
-	return data, nil
+	return data[:dlen-last], nil
 }
 
 // EncryptPKCS8PrivateKey returns a PEM block holding the given PKCS#8 encroded

--- a/pemutil/pkcs8.go
+++ b/pemutil/pkcs8.go
@@ -182,7 +182,11 @@ func DecryptPEMBlock(block *pem.Block, password []byte) ([]byte, error) {
 }
 
 // DecryptPKCS8PrivateKey takes a password encrypted private key using the
-// PKCS#8 encoding and returns the decrypted data in PKCS#8 form.
+// PKCS#8 encoding and returns the decrypted data in PKCS#8 form. If an
+// incorrect password is detected an x509.IncorrectPasswordError is returned.
+// Because of deficiencies in the format, it's not always possible to detect an
+// incorrect password. In these cases no error will be returned but the
+// decrypted DER bytes will be random noise.
 //
 // It supports AES-128-CBC, AES-192-CBC, AES-256-CBC, DES, or 3DES encrypted
 // data using the key derived with PBKDF2 over the given password.
@@ -213,7 +217,6 @@ func DecryptPKCS8PrivateKey(data, password []byte) ([]byte, error) {
 		keyHash = sha256.New
 	}
 
-	encryptedKey := pki.PrivateKey
 	var symkey []byte
 	var block cipher.Block
 	var err error
@@ -242,10 +245,36 @@ func DecryptPKCS8PrivateKey(data, password []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	data = pki.PrivateKey
 	mode := cipher.NewCBCDecrypter(block, iv)
-	mode.CryptBlocks(encryptedKey, encryptedKey)
+	mode.CryptBlocks(data, data)
 
-	return encryptedKey, nil
+	// Blocks are padded using a scheme where the last n bytes of padding are all
+	// equal to n. It can pad from 1 to blocksize bytes inclusive. See RFC 1423.
+	// For example:
+	//	[x y z 2 2]
+	//	[x y 7 7 7 7 7 7 7]
+	// If we detect a bad padding, we assume it is an invalid password.
+	blockSize := block.BlockSize()
+	dlen := len(data)
+	if dlen == 0 || dlen%blockSize != 0 {
+		return nil, errors.New("error decrypting PEM: invalid padding")
+	}
+
+	last := int(data[dlen-1])
+	if dlen < last {
+		return nil, x509.IncorrectPasswordError
+	}
+	if last == 0 || last > blockSize {
+		return nil, x509.IncorrectPasswordError
+	}
+	for _, val := range data[dlen-last:] {
+		if int(val) != last {
+			return nil, x509.IncorrectPasswordError
+		}
+	}
+
+	return data, nil
 }
 
 // EncryptPKCS8PrivateKey returns a PEM block holding the given PKCS#8 encroded


### PR DESCRIPTION
### Description

This PR return `x509.IncorrectPasswordError` in and invalid password is detected on `DecryptPEMBlock`, `DecryptPKCS8PrivateKey` and `ParseCosignPrivateKey`.

Fixes #23