### PR TITLE
Remove env and expandenv

### DIFF
--- a/sshutil/options.go
+++ b/sshutil/options.go
@@ -15,6 +15,9 @@ import (
 // function "fail" to set the given string, this way we can report template
 // errors directly to the template without having the wrapper that text/template
 // adds.
+//
+// sprig "env" and "expandenv" functions are removed to avoid the leak of
+// information.
 func getFuncMap(failMessage *string) template.FuncMap {
 	m := sprig.TxtFuncMap()
 	delete(m, "env")

--- a/x509util/options.go
+++ b/x509util/options.go
@@ -16,6 +16,9 @@ import (
 // function "fail" to set the given string, this way we can report template
 // errors directly to the template without having the wrapper that text/template
 // adds.
+//
+// sprig "env" and "expandenv" functions are removed to avoid the leak of
+// information.
 func getFuncMap(failMessage *string) template.FuncMap {
 	m := sprig.TxtFuncMap()
 	delete(m, "env")


### PR DESCRIPTION
### Description

This PR removes the sprig `env` and `expandenv` functions.