### PR TITLE
Add Bytes() function

### DIFF
--- a/randutil/random.go
+++ b/randutil/random.go
@@ -31,6 +31,16 @@ func Salt(size int) ([]byte, error) {
 	return salt, nil
 }
 
+// Bytes generates a new byte slice of the given size.
+func Bytes(size int) ([]byte, error) {
+	bytes := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating bytes")
+	}
+	return bytes, nil
+}
+
 // String returns a random string of a given length using the characters in
 // the given string. It splits the string on runes to support UTF-8
 // characters.

--- a/randutil/random_test.go
+++ b/randutil/random_test.go
@@ -59,6 +59,18 @@ func TestSalt(t *testing.T) {
 	}
 }
 
+func TestBytes(t *testing.T) {
+	sizes := []int{4, 8, 16, 32, 64, 128}
+	for _, size := range sizes {
+		a, err := Bytes(size)
+		assert.NoError(t, err)
+		b, err := Bytes(size)
+		assert.NoError(t, err)
+		// Most of the time
+		assert.NotEquals(t, a, b)
+	}
+}
+
 func TestString(t *testing.T) {
 	re := regexp.MustCompilePOSIX(`^[0-9世界ñçàèìòù]+$`)
 	chars := "0123456789世界ñçàèìòù"


### PR DESCRIPTION
We could call `Salt()` or the other way around, but it's only a little bit of duplicate code, so I figured it's OK to do like this.