### PR TITLE
Add ExtraNames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       -
         name: Checkout
@@ -26,7 +26,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.44.0'
+          version: 'v1.45.2'
           args: --timeout=30m
       -
         name: Test, Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       -
         name: Checkout
@@ -28,7 +28,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.44.0'
+          version: 'v1.45.2'
           args: --timeout=30m
       -
         name: Test, Build
@@ -37,7 +37,7 @@ jobs:
       -
         name: Codecov
         uses: codecov/codecov-action@v1.2.1
-        if: matrix.go == '1.17'
+        if: matrix.go == '1.18'
         with:
           file: ./coverage.out
           name: codecov-umbrella

--- a/minica/minica.go
+++ b/minica/minica.go
@@ -14,6 +14,7 @@ import (
 // CA is the implementation of a simple X.509 and SSH CA.
 type CA struct {
 	Root          *x509.Certificate
+	RootSigner    crypto.Signer
 	Intermediate  *x509.Certificate
 	Signer        crypto.Signer
 	SSHHostSigner ssh.Signer
@@ -92,6 +93,7 @@ func New(opts ...Option) (*CA, error) {
 
 	return &CA{
 		Root:          root,
+		RootSigner:    rootSigner,
 		Intermediate:  intermediate,
 		Signer:        intSigner,
 		SSHHostSigner: sshHostSigner,

--- a/x509util/certpool_test.go
+++ b/x509util/certpool_test.go
@@ -30,7 +30,7 @@ func TestReadCertPool(t *testing.T) {
 				return
 			}
 			if got != nil {
-				// noline:staticcheck // there's no other way to compare two
+				// nolint:staticcheck // there's no other way to compare two
 				// certpools, https://github.com/golang/go/issues/46057 might
 				// fix this.
 				subjects := got.Subjects()

--- a/x509util/certpool_test.go
+++ b/x509util/certpool_test.go
@@ -30,6 +30,9 @@ func TestReadCertPool(t *testing.T) {
 				return
 			}
 			if got != nil {
+				// noline:staticcheck // there's no other way to compare two
+				// certpools, https://github.com/golang/go/issues/46057 might
+				// fix this.
 				subjects := got.Subjects()
 				if !reflect.DeepEqual(subjects, tt.wantSubjects) {
 					t.Errorf("x509.CertPool.Subjects() got = %v, want %v", subjects, tt.wantSubjects)


### PR DESCRIPTION
### Description
This PR adds ExtraNames to X.509 subject and issuers, so they can be templatized. One use of this is adding the deprecated DN emailAddress.

This PR also exposes the root signer in minica and fixes linter errors with Go 1.18.