### PR TITLE
Insecure mode

### DIFF
--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -32,6 +32,16 @@ var (
 	MinRSAKeyBytes = 256
 )
 
+// Insecure removes minimum limits on on the RSA key size and returns a function
+// to revert the configuration.
+func Insecure() (revert func()) {
+	minRSAKeyBytes := MinRSAKeyBytes
+	MinRSAKeyBytes = 0
+	return func() {
+		MinRSAKeyBytes = minRSAKeyBytes
+	}
+}
+
 // PublicKey extracts a public key from a private key.
 func PublicKey(priv interface{}) (crypto.PublicKey, error) {
 	switch k := priv.(type) {

--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"go.step.sm/crypto/x25519"
@@ -32,13 +33,21 @@ var (
 	MinRSAKeyBytes = 256
 )
 
-// Insecure removes minimum limits on on the RSA key size and returns a function
-// to revert the configuration.
+type atomicBool int32
+
+func (b *atomicBool) isSet() bool { return atomic.LoadInt32((*int32)(b)) != 0 }
+func (b *atomicBool) setTrue()    { atomic.StoreInt32((*int32)(b), 1) }
+func (b *atomicBool) setFalse()   { atomic.StoreInt32((*int32)(b), 0) }
+
+var insecureMode atomicBool
+
+// Insecure enables the insecure mode in this package and returns a function to
+// revert the configuration. The insecure mode removes the minimum limits when
+// generating RSA keys.
 func Insecure() (revert func()) {
-	minRSAKeyBytes := MinRSAKeyBytes
-	MinRSAKeyBytes = 0
+	insecureMode.setTrue()
 	return func() {
-		MinRSAKeyBytes = minRSAKeyBytes
+		insecureMode.setFalse()
 	}
 }
 
@@ -194,7 +203,7 @@ func generateECKey(crv string) (crypto.Signer, error) {
 }
 
 func generateRSAKey(bits int) (crypto.Signer, error) {
-	if min := MinRSAKeyBytes * 8; bits < min {
+	if min := MinRSAKeyBytes * 8; !insecureMode.isSet() && bits < min {
 		return nil, errors.Errorf("the size of the RSA key should be at least %d bits", min)
 	}
 

--- a/keyutil/key_test.go
+++ b/keyutil/key_test.go
@@ -540,3 +540,41 @@ func TestVerifyPair(t *testing.T) {
 		})
 	}
 }
+
+func TestInsecure(t *testing.T) {
+	tests := []struct {
+		name    string
+		run     func(t *testing.T) error
+		wantErr bool
+	}{
+		{"ok RSA 2048", func(t *testing.T) (err error) {
+			_, err = GenerateKey("RSA", "", 2048)
+			return
+		}, false},
+		{"fail RSA 1024", func(t *testing.T) (err error) {
+			_, err = GenerateKey("RSA", "", 1024)
+			return
+		}, true},
+		{"ok RSA 2048 insecure", func(t *testing.T) (err error) {
+			revert := Insecure()
+			t.Cleanup(revert)
+			_, err = GenerateKey("RSA", "", 2048)
+			return
+		}, false},
+		{"ok RSA 1024 insecure", func(t *testing.T) (err error) {
+			revert := Insecure()
+			t.Cleanup(revert)
+			_, err = GenerateKey("RSA", "", 1024)
+			return
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Insecure() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR adds a new method, `keyutil.Insecure()`, that allows the creation of insecure RSA keys. This can be required, for example, by `step` to create legacy keys.

Note: I'm not using atomic.Bool because it is not available in 1.18