### PR TITLE
Marshal keys

### DIFF
--- a/pemutil/marshal.go
+++ b/pemutil/marshal.go
@@ -1,0 +1,57 @@
+package pemutil
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var oidEd25519 = asn1.ObjectIdentifier{1, 3, 101, 112}
+
+// MarshalPKIXPublicKey serializes a public key to DER-encoded PKIX format. The
+// following key types are supported: *rsa.PublicKey, *ecdsa.PublicKey,
+// ed25519.Publickey. Unsupported key types result in an error.
+func MarshalPKIXPublicKey(pub crypto.PublicKey) ([]byte, error) {
+	switch p := pub.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey:
+		return x509.MarshalPKIXPublicKey(pub)
+	case ed25519.PublicKey:
+		var pki publicKeyInfo
+		pki.Algo.Algorithm = oidEd25519
+		pki.PublicKey = asn1.BitString{
+			Bytes:     p,
+			BitLength: 8 * len(p),
+		}
+		return asn1.Marshal(pki)
+	default:
+		return nil, fmt.Errorf("unknown public key type: %T", pub)
+	}
+}
+
+// MarshalPKCS8PrivateKey converts a private key to PKCS#8 encoded form. The
+// following key types are supported: *rsa.PrivateKey, *ecdsa.PublicKey,
+// ed25519.PrivateKey. Unsupported key types result in an error.
+func MarshalPKCS8PrivateKey(key crypto.PrivateKey) ([]byte, error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey, *ecdsa.PrivateKey:
+		b, err := x509.MarshalPKCS8PrivateKey(key)
+		return b, errors.Wrap(err, "error marshaling PKCS#8")
+	case ed25519.PrivateKey:
+		var priv pkcs8
+		priv.PrivateKey = append([]byte{4, 32}, k.Seed()...)[:34]
+		priv.Algo = pkix.AlgorithmIdentifier{
+			Algorithm: asn1.ObjectIdentifier{1, 3, 101, 112},
+		}
+		b, err := asn1.Marshal(priv)
+		return b, errors.Wrap(err, "error marshaling PKCS#8")
+	default:
+		return nil, errors.Errorf("x509: unknown key type while marshaling PKCS#8: %T", key)
+	}
+}

--- a/pemutil/marshal_test.go
+++ b/pemutil/marshal_test.go
@@ -1,0 +1,91 @@
+package pemutil
+
+import (
+	"crypto"
+	"encoding/pem"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func mustRead(t *testing.T, filename string) crypto.PublicKey {
+	t.Helper()
+
+	key, err := Read(filename)
+	if err != nil {
+		t.Fatalf("error parsing %s: %v", filename, err)
+	}
+	return key
+}
+
+func mustDecode(t *testing.T, filename string) []byte {
+	t.Helper()
+
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(b)
+	if block == nil {
+		t.Fatalf("error decoding %s: failed to parse pem", filename)
+	}
+	return block.Bytes
+}
+
+func TestMarshalPKIXPublicKey(t *testing.T) {
+	type args struct {
+		pub crypto.PublicKey
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{"p256", args{mustRead(t, "testdata/openssl.p256.pub.pem")}, mustDecode(t, "testdata/openssl.p256.pub.pem"), false},
+		{"rsa2048", args{mustRead(t, "testdata/openssl.rsa2048.pub.pem")}, mustDecode(t, "testdata/openssl.rsa2048.pub.pem"), false},
+		{"ed25519", args{mustRead(t, "testdata/pkcs8/openssl.ed25519.pub.pem")}, mustDecode(t, "testdata/pkcs8/openssl.ed25519.pub.pem"), false},
+		{"fail", args{"not a key"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MarshalPKIXPublicKey(tt.args.pub)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalPKIXPublicKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalPKIXPublicKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalPKCS8PrivateKey(t *testing.T) {
+	type args struct {
+		key crypto.PrivateKey
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{"p256", args{mustRead(t, "testdata/pkcs8/openssl.p256.pem")}, mustDecode(t, "testdata/pkcs8/openssl.p256.pem"), false},
+		{"rsa2048", args{mustRead(t, "testdata/pkcs8/openssl.rsa2048.pem")}, mustDecode(t, "testdata/pkcs8/openssl.rsa2048.pem"), false},
+		{"ed25519", args{mustRead(t, "testdata/pkcs8/openssl.ed25519.pem")}, mustDecode(t, "testdata/pkcs8/openssl.ed25519.pem"), false},
+		{"fail", args{"not a key"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MarshalPKCS8PrivateKey(tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalPKCS8PrivateKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalPKCS8PrivateKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR adds MarshalPKIXPublicKey and MarshalPKCS8PrivateKey, these methods are used in `step` and should be available in `go.step.sm/crypto`.