### PR TITLE
Fix branch for ci job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: smallstep/crypto/.github/workflows/ci.yml@main
+    uses: smallstep/crypto/.github/workflows/ci.yml@master
     secrets: inherit
 
   create_release:


### PR DESCRIPTION
### Description

crypto principal branch is `master` not `main`