### PR TITLE
YubiKey pin and touch policies

### DIFF
--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -19,6 +19,35 @@ const (
 	HSM
 )
 
+// PINPolicy represents PIN requirements when signing or decrypting with an
+// asymmetric key in a given slot. PINPolicy is used by the YubiKey KMS.
+type PINPolicy int
+
+// PIN policies supported by this package. The values must match the ones in
+// github.com/go-piv/piv-go/piv.
+//
+// Caching for PINPolicyOnce isn't supported on YubiKey
+// versions older than 4.3.0 due to issues with verifying if a PIN is needed.
+// If specified, a PIN will be required for every operation.
+const (
+	PINPolicyNever PINPolicy = iota + 1
+	PINPolicyOnce
+	PINPolicyAlways
+)
+
+// TouchPolicy represents proof-of-presence requirements when signing or
+// decrypting with asymmetric key in a given slot. PINPolicy is used by the
+// YubiKey KMS.
+type TouchPolicy int
+
+// Touch policies supported by this package. The values must match the ones in
+// github.com/go-piv/piv-go/piv.
+const (
+	TouchPolicyNever TouchPolicy = iota + 1
+	TouchPolicyAlways
+	TouchPolicyCached
+)
+
 // String returns a string representation of p.
 func (p ProtectionLevel) String() string {
 	switch p {
@@ -118,6 +147,18 @@ type CreateKeyRequest struct {
 	//
 	// Used by: pkcs11
 	Extractable bool
+
+	// PINPolicy defines PIN requirements when signing or decrypting with an
+	// asymmetric key.
+	//
+	// Used by: yubikey
+	PINPolicy PINPolicy
+
+	// TouchPolicy represents proof-of-presence requirements when signing or
+	// decrypting with asymmetric key in a given slot.
+	//
+	// Used by: yubikey
+	TouchPolicy TouchPolicy
 }
 
 // CreateKeyResponse is the response value of the kms.CreateKey method.

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -36,7 +36,7 @@ const (
 )
 
 // TouchPolicy represents proof-of-presence requirements when signing or
-// decrypting with asymmetric key in a given slot. PINPolicy is used by the
+// decrypting with asymmetric key in a given slot. TouchPolicy is used by the
 // YubiKey KMS.
 type TouchPolicy int
 


### PR DESCRIPTION
### Description

The YubiKey KMS allows to set pin and touch policies when a key is created, these policies are used when signing or decrypting with an asymmetric key in a slot.

The default pin policy is set to always and the touch policy to never, but now the values can be configurable.

`step-kms-plugin` will add `--pin-policy` and `--touch-policy` flags to be able to configure these.
