### PR TITLE
Add method to close the kms FSs

### DIFF
--- a/kms/kmsfs.go
+++ b/kms/kmsfs.go
@@ -8,15 +8,28 @@ import (
 	"go.step.sm/crypto/kms/apiv1"
 )
 
+// FS adds a close method to the fs.FS interface. This new method allows to
+// properly close the underlying KMS.
+type FS interface {
+	fs.FS
+	Close() error
+}
+
 type kmsfs struct {
 	apiv1.KeyManager
+}
+
+func (k *kmsfs) Close() error {
+	if k != nil && k.KeyManager != nil {
+		return k.KeyManager.Close()
+	}
+	return nil
 }
 
 func newFS(ctx context.Context, kmsuri string) (*kmsfs, error) {
 	if kmsuri == "" {
 		return &kmsfs{}, nil
 	}
-
 	km, err := loadKMS(ctx, kmsuri)
 	if err != nil {
 		return nil, err
@@ -51,7 +64,7 @@ type certFS struct {
 }
 
 // CertFS creates a new io/fs with the given KMS URI.
-func CertFS(ctx context.Context, kmsuri string) (fs.FS, error) {
+func CertFS(ctx context.Context, kmsuri string) (FS, error) {
 	km, err := newFS(ctx, kmsuri)
 	if err != nil {
 		return nil, err
@@ -87,7 +100,7 @@ type keyFS struct {
 }
 
 // KeyFS creates a new KeyFS with the given KMS URI.
-func KeyFS(ctx context.Context, kmsuri string) (fs.FS, error) {
+func KeyFS(ctx context.Context, kmsuri string) (FS, error) {
 	km, err := newFS(ctx, kmsuri)
 	if err != nil {
 		return nil, err

--- a/kms/kmsfs.go
+++ b/kms/kmsfs.go
@@ -19,13 +19,6 @@ type kmsfs struct {
 	apiv1.KeyManager
 }
 
-func (k *kmsfs) Close() error {
-	if k != nil && k.KeyManager != nil {
-		return k.KeyManager.Close()
-	}
-	return nil
-}
-
 func newFS(ctx context.Context, kmsuri string) (*kmsfs, error) {
 	if kmsuri == "" {
 		return &kmsfs{}, nil
@@ -35,6 +28,13 @@ func newFS(ctx context.Context, kmsuri string) (*kmsfs, error) {
 		return nil, err
 	}
 	return &kmsfs{KeyManager: km}, nil
+}
+
+func (f *kmsfs) Close() error {
+	if f != nil && f.KeyManager != nil {
+		return f.KeyManager.Close()
+	}
+	return nil
 }
 
 func (f *kmsfs) getKMS(kmsuri string) (apiv1.KeyManager, error) {

--- a/kms/kmsfs_test.go
+++ b/kms/kmsfs_test.go
@@ -77,6 +77,9 @@ func Test_new(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("new() = %v, want %v", got, tt.want)
 			}
+			if err := got.Close(); err != nil {
+				t.Errorf("Close() error = %v, wantErr false", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Description

This PR wraps the fs.FS interface with an extra method to properly close the KMS. I first tried to use the context to do the same, but it was causing random panics in the Go runtime.