### PR TITLE
Use Equal to verify a keypair

### DIFF
--- a/jose/types.go
+++ b/jose/types.go
@@ -5,12 +5,12 @@ package jose
 import (
 	"crypto"
 	"errors"
-	"gopkg.in/square/go-jose.v2/cryptosigner"
 	"strings"
 	"time"
 
 	"go.step.sm/crypto/x25519"
 	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/cryptosigner"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -253,8 +253,8 @@ func NewSigner(sig SigningKey, opts *SignerOptions) (Signer, error) {
 }
 
 // NewOpaqueSigner creates a new OpaqueSigner for JWT signing from a crypto.Signer
-func NewOpaqueSigner(signer *crypto.Signer) OpaqueSigner {
-	return cryptosigner.Opaque(*signer)
+func NewOpaqueSigner(signer crypto.Signer) OpaqueSigner {
+	return cryptosigner.Opaque(signer)
 }
 
 // Verify validates the token payload with the given public key and deserializes

--- a/jose/validate_test.go
+++ b/jose/validate_test.go
@@ -158,7 +158,7 @@ func TestValidateX5C(t *testing.T) {
 			assert.FatalError(t, err)
 			sig, ok := k.(crypto.Signer)
 			assert.True(t, ok)
-			op := NewOpaqueSigner(&sig)
+			op := NewOpaqueSigner(sig)
 			return test{
 				certs: certs,
 				key:   op,

--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -2,7 +2,6 @@
 package keyutil
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -156,7 +155,7 @@ func VerifyPair(pubkey crypto.PublicKey, key crypto.PrivateKey) error {
 		if !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		if pub.N.Cmp(priv.N) != 0 {
+		if !pub.Equal(priv.Public()) {
 			return errors.New("private key does not match public key")
 		}
 	case *ecdsa.PublicKey:
@@ -164,7 +163,7 @@ func VerifyPair(pubkey crypto.PublicKey, key crypto.PrivateKey) error {
 		if !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		if pub.X.Cmp(priv.X) != 0 || pub.Y.Cmp(priv.Y) != 0 {
+		if !pub.Equal(priv.Public()) {
 			return errors.New("private key does not match public key")
 		}
 	case ed25519.PublicKey:
@@ -172,7 +171,7 @@ func VerifyPair(pubkey crypto.PublicKey, key crypto.PrivateKey) error {
 		if !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		if !bytes.Equal(priv.Public().(ed25519.PublicKey), pub) {
+		if !pub.Equal(priv.Public()) {
 			return errors.New("private key does not match public key")
 		}
 	default:


### PR DESCRIPTION
### Description

This PR changes the keypair verification to use the Equal method. Now the RSA key exponent is also verified, that was a problem with the previous version.

This method can also be simplified using crypto.Signer and an "Equaler" interface, but I've decided to leave it as it currently is.