### PR TITLE
Add tags to remove KMSs at compile time

### DIFF
--- a/kms/awskms/awskms.go
+++ b/kms/awskms/awskms.go
@@ -1,3 +1,6 @@
+//go:build !noawskms
+// +build !noawskms
+
 package awskms
 
 import (

--- a/kms/awskms/no_awskms.go
+++ b/kms/awskms/no_awskms.go
@@ -1,0 +1,20 @@
+//go:build noawskms
+// +build noawskms
+
+package awskms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func init() {
+	apiv1.Register(apiv1.AmazonKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		name := filepath.Base(os.Args[0])
+		return nil, errors.Errorf("unsupported kms type 'awskms': %s is compiled without Amazon KMS support", name)
+	})
+}

--- a/kms/awskms/signer.go
+++ b/kms/awskms/signer.go
@@ -1,3 +1,6 @@
+//go:build !noawskms
+// +build !noawskms
+
 package awskms
 
 import (

--- a/kms/azurekms/key_vault.go
+++ b/kms/azurekms/key_vault.go
@@ -1,3 +1,6 @@
+//go:build !noazurekms
+// +build !noazurekms
+
 package azurekms
 
 import (

--- a/kms/azurekms/no_azurekms.go
+++ b/kms/azurekms/no_azurekms.go
@@ -1,0 +1,20 @@
+//go:build noazurekms
+// +build noazurekms
+
+package azurekms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func init() {
+	apiv1.Register(apiv1.AzureKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		name := filepath.Base(os.Args[0])
+		return nil, errors.Errorf("unsupported kms type 'azurekms': %s is compiled without Azure KMS support", name)
+	})
+}

--- a/kms/azurekms/signer.go
+++ b/kms/azurekms/signer.go
@@ -1,3 +1,6 @@
+//go:build !noazurekms
+// +build !noazurekms
+
 package azurekms
 
 import (

--- a/kms/azurekms/utils.go
+++ b/kms/azurekms/utils.go
@@ -1,3 +1,6 @@
+//go:build !noazurekms
+// +build !noazurekms
+
 package azurekms
 
 import (

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && !nocapi
+// +build windows,!nocapi
 
 package capi
 
@@ -14,6 +14,12 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"math/big"
+	"reflect"
+	"strings"
+	"unsafe"
+
 	"github.com/pkg/errors"
 	"go.step.sm/crypto/kms/apiv1"
 	"go.step.sm/crypto/kms/uri"
@@ -21,11 +27,6 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 	"golang.org/x/sys/windows"
-	"io"
-	"math/big"
-	"reflect"
-	"strings"
-	"unsafe"
 )
 
 // Scheme is the scheme used in uris.
@@ -78,7 +79,6 @@ var signatureAlgorithmMapping = map[apiv1.SignatureAlgorithm]string{
 // "key-id"           X509v3 Subject Key Identifier of the certificate to load in hex format
 // "serial"           serial number of the certificate to load in hex format
 // "issuer"           Common Name of the certificate issuer
-//
 type CAPIKMS struct {
 	providerName   string
 	providerHandle uintptr

--- a/kms/capi/no_capi.go
+++ b/kms/capi/no_capi.go
@@ -1,0 +1,20 @@
+//go:build !windows || nocapi
+// +build !windows nocapi
+
+package cloudkms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func init() {
+	apiv1.Register(apiv1.CAPIKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		name := filepath.Base(os.Args[0])
+		return nil, errors.Errorf("unsupported kms type 'capi': %s is compiled without Microsoft CryptoAPI support", name)
+	})
+}

--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -1,3 +1,6 @@
+//go:build !nocloudkms
+// +build !nocloudkms
+
 package cloudkms
 
 import (

--- a/kms/cloudkms/no_cloudkms.go
+++ b/kms/cloudkms/no_cloudkms.go
@@ -1,0 +1,20 @@
+//go:build nocloudkms
+// +build nocloudkms
+
+package cloudkms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func init() {
+	apiv1.Register(apiv1.CloudKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		name := filepath.Base(os.Args[0])
+		return nil, errors.Errorf("unsupported kms type 'cloudkms': %s is compiled without Google Cloud Key Management support", name)
+	})
+}

--- a/kms/cloudkms/signer.go
+++ b/kms/cloudkms/signer.go
@@ -1,3 +1,6 @@
+//go:build !nocloudkms
+// +build !nocloudkms
+
 package cloudkms
 
 import (

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !nopkcs11
+// +build cgo,!nopkcs11
 
 package pkcs11
 

--- a/kms/pkcs11/pkcs11_no_cgo.go
+++ b/kms/pkcs11/pkcs11_no_cgo.go
@@ -1,5 +1,5 @@
-//go:build !cgo
-// +build !cgo
+//go:build !cgo || nopkcs11
+// +build !cgo nopkcs11
 
 package pkcs11
 
@@ -17,7 +17,7 @@ var errUnsupported error
 
 func init() {
 	name := filepath.Base(os.Args[0])
-	errUnsupported = errors.Errorf("unsupported kms type 'pkcs11': %s is compiled without cgo support", name)
+	errUnsupported = errors.Errorf("unsupported kms type 'pkcs11': %s is compiled without CGO or PKCS#11 support", name)
 
 	apiv1.Register(apiv1.PKCS11, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
 		return nil, errUnsupported

--- a/kms/pkcs11/pkcs11_no_cgo.go
+++ b/kms/pkcs11/pkcs11_no_cgo.go
@@ -17,7 +17,7 @@ var errUnsupported error
 
 func init() {
 	name := filepath.Base(os.Args[0])
-	errUnsupported = errors.Errorf("unsupported kms type 'pkcs11': %s is compiled without CGO or PKCS#11 support", name)
+	errUnsupported = errors.Errorf("unsupported kms type 'pkcs11': %s is compiled without cgo or PKCS#11 support", name)
 
 	apiv1.Register(apiv1.PKCS11, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
 		return nil, errUnsupported

--- a/kms/sshagentkms/no_sshagentkms.go
+++ b/kms/sshagentkms/no_sshagentkms.go
@@ -1,0 +1,20 @@
+//go:build nosshagentkms
+// +build nosshagentkms
+
+package sshagentkms
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func init() {
+	apiv1.Register(apiv1.SSHAgentKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		name := filepath.Base(os.Args[0])
+		return nil, errors.Errorf("unsupported kms type 'sshagentkms': %s is compiled without SSH Agent KMS support", name)
+	})
+}

--- a/kms/sshagentkms/sshagentkms.go
+++ b/kms/sshagentkms/sshagentkms.go
@@ -1,3 +1,6 @@
+//go:build !nosshagentkms
+// +build !nosshagentkms
+
 package sshagentkms
 
 import (

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -1,5 +1,5 @@
-//go:build cgo
-// +build cgo
+//go:build cgo && !noyubikey
+// +build cgo,!noyubikey
 
 package yubikey
 

--- a/kms/yubikey/yubikey_no_cgo.go
+++ b/kms/yubikey/yubikey_no_cgo.go
@@ -1,5 +1,5 @@
-//go:build !cgo
-// +build !cgo
+//go:build !cgo || noyubikey
+// +build !cgo noyubikey
 
 package yubikey
 
@@ -15,6 +15,6 @@ import (
 func init() {
 	apiv1.Register(apiv1.YubiKey, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
 		name := filepath.Base(os.Args[0])
-		return nil, errors.Errorf("unsupported kms type 'yubikey': %s is compiled without cgo support", name)
+		return nil, errors.Errorf("unsupported kms type 'yubikey': %s is compiled without CGO or YubiKey support", name)
 	})
 }

--- a/kms/yubikey/yubikey_no_cgo.go
+++ b/kms/yubikey/yubikey_no_cgo.go
@@ -15,6 +15,6 @@ import (
 func init() {
 	apiv1.Register(apiv1.YubiKey, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
 		name := filepath.Base(os.Args[0])
-		return nil, errors.Errorf("unsupported kms type 'yubikey': %s is compiled without CGO or YubiKey support", name)
+		return nil, errors.Errorf("unsupported kms type 'yubikey': %s is compiled without cgo or YubiKey support", name)
 	})
 }


### PR DESCRIPTION
### Description

This PR adds support for passing the following tags to exclude a specific KMS from a binary:
 - noawskms
 - noazurekms
 - nocapi
 - nocloudkms
 - nopkcs11
 - nosshagentkms
 - noyubikey

Fixes #163
