### PR TITLE
Allow crypto.Signer in keyutil.PublicKey() method

### DIFF
--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -63,6 +63,8 @@ func PublicKey(priv interface{}) (crypto.PublicKey, error) {
 		return k.Public(), nil
 	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, x25519.PublicKey:
 		return k, nil
+	case crypto.Signer:
+		return k.Public(), nil
 	default:
 		return nil, errors.Errorf("unrecognized key type: %T", priv)
 	}

--- a/keyutil/key_test.go
+++ b/keyutil/key_test.go
@@ -132,7 +132,11 @@ func verifyPrivateKey(h crypto.Hash, priv interface{}) error {
 }
 
 func TestPublicKey(t *testing.T) {
+	type opaqueSigner struct {
+		crypto.Signer
+	}
 	ecdsaKey := must(generateECKey("P-256")).(*ecdsa.PrivateKey)
+	ecdsaSigner := opaqueSigner{ecdsaKey}
 	rsaKey := must(generateRSAKey(2048)).(*rsa.PrivateKey)
 	ed25519Key := must(generateOKPKey("Ed25519")).(ed25519.PrivateKey)
 	x25519Pub, x25519Priv, err := x25519.GenerateKey(rand.Reader)
@@ -155,6 +159,7 @@ func TestPublicKey(t *testing.T) {
 		{"ed25519Public", args{ed25519.PublicKey(ed25519Key[32:])}, ed25519Key.Public(), false},
 		{"x25519", args{x25519Priv}, x25519Pub, false},
 		{"x25519Public", args{x25519Pub}, x25519Pub, false},
+		{"ecdsaSigner", args{ecdsaSigner}, ecdsaKey.Public(), false},
 		{"fail", args{[]byte("octkey")}, nil, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

This commit allows getting the public key from a `crypto.Signer` using the `keyutil.PublicKey(priv interface{})` method.
