### PR TITLE
Add support for sovereign clouds on Azure KeyVault

### DIFF
--- a/kms/azurekms/signer.go
+++ b/kms/azurekms/signer.go
@@ -30,7 +30,7 @@ type Signer struct {
 
 // NewSigner creates a new signer using a key in the AWS KMS.
 func NewSigner(client KeyVaultClient, signingKey string, defaults DefaultOptions) (crypto.Signer, error) {
-	vault, name, version, _, err := parseKeyName(signingKey, defaults)
+	vault, name, version, dnsSuffix, _, err := parseKeyName(signingKey, defaults)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func NewSigner(client KeyVaultClient, signingKey string, defaults DefaultOptions
 	// Make sure that the key exists.
 	signer := &Signer{
 		client:       client,
-		vaultBaseURL: vaultBaseURL(vault),
+		vaultBaseURL: vaultBaseURL(vault, dnsSuffix),
 		name:         name,
 		version:      version,
 	}

--- a/kms/azurekms/utils.go
+++ b/kms/azurekms/utils.go
@@ -57,7 +57,7 @@ func getKeyName(vault, name string, bundle keyvault.KeyBundle) string {
 //
 // HSM can also be passed to define the protection level if this is not given in
 // CreateQuery.
-func parseKeyName(rawURI string, defaults DefaultOptions) (vault, name, version string, hsm bool, err error) {
+func parseKeyName(rawURI string, defaults DefaultOptions) (vault, name, version, dnsSuffix string, hsm bool, err error) {
 	var u *uri.URI
 
 	u, err = uri.ParseWithScheme(Scheme, rawURI)
@@ -83,12 +83,17 @@ func parseKeyName(rawURI string, defaults DefaultOptions) (vault, name, version 
 	}
 
 	version = u.Get("version")
+	dnsSuffix = defaults.Environment.KeyVaultDNSSuffix
 
 	return
 }
 
-func vaultBaseURL(vault string) string {
-	return "https://" + vault + ".vault.azure.net/"
+func vaultBaseURL(vault, dnsSuffix string) string {
+	if dnsSuffix == "" {
+		return "https://" + vault + ".vault.azure.net/"
+	}
+
+	return "https://" + vault + "." + dnsSuffix + "/"
 }
 
 func convertKey(key *keyvault.JSONWebKey) (crypto.PublicKey, error) {

--- a/kms/azurekms/utils_test.go
+++ b/kms/azurekms/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"go.step.sm/crypto/kms/apiv1"
 )
 
@@ -46,38 +47,41 @@ func Test_getKeyName(t *testing.T) {
 }
 
 func Test_parseKeyName(t *testing.T) {
-	var noOptions DefaultOptions
+	var noOptions, publicOptions, sovereignOptions DefaultOptions
+	publicOptions.Environment = azure.PublicCloud
+	sovereignOptions.Environment = azure.USGovernmentCloud
 	type args struct {
 		rawURI   string
 		defaults DefaultOptions
 	}
 	tests := []struct {
-		name        string
-		args        args
-		wantVault   string
-		wantName    string
-		wantVersion string
-		wantHsm     bool
-		wantErr     bool
+		name          string
+		args          args
+		wantVault     string
+		wantName      string
+		wantVersion   string
+		wantDNSSuffix string
+		wantHsm       bool
+		wantErr       bool
 	}{
-		{"ok", args{"azurekms:name=my-key;vault=my-vault?version=my-version", noOptions}, "my-vault", "my-key", "my-version", false, false},
-		{"ok opaque version", args{"azurekms:name=my-key;vault=my-vault;version=my-version", noOptions}, "my-vault", "my-key", "my-version", false, false},
-		{"ok no version", args{"azurekms:name=my-key;vault=my-vault", noOptions}, "my-vault", "my-key", "", false, false},
-		{"ok hsm", args{"azurekms:name=my-key;vault=my-vault?hsm=true", noOptions}, "my-vault", "my-key", "", true, false},
-		{"ok hsm false", args{"azurekms:name=my-key;vault=my-vault?hsm=false", noOptions}, "my-vault", "my-key", "", false, false},
-		{"ok default vault", args{"azurekms:name=my-key?version=my-version", DefaultOptions{Vault: "my-vault"}}, "my-vault", "my-key", "my-version", false, false},
-		{"ok default hsm", args{"azurekms:name=my-key;vault=my-vault?version=my-version", DefaultOptions{Vault: "other-vault", ProtectionLevel: apiv1.HSM}}, "my-vault", "my-key", "my-version", true, false},
-		{"fail scheme", args{"azure:name=my-key;vault=my-vault", noOptions}, "", "", "", false, true},
-		{"fail parse uri", args{"azurekms:name=%ZZ;vault=my-vault", noOptions}, "", "", "", false, true},
-		{"fail no name", args{"azurekms:vault=my-vault", noOptions}, "", "", "", false, true},
-		{"fail empty name", args{"azurekms:name=;vault=my-vault", noOptions}, "", "", "", false, true},
-		{"fail no vault", args{"azurekms:name=my-key", noOptions}, "", "", "", false, true},
-		{"fail empty vault", args{"azurekms:name=my-key;vault=", noOptions}, "", "", "", false, true},
-		{"fail empty", args{"", noOptions}, "", "", "", false, true},
+		{"ok", args{"azurekms:name=my-key;vault=my-vault?version=my-version", noOptions}, "my-vault", "my-key", "my-version", "", false, false},
+		{"ok opaque version", args{"azurekms:name=my-key;vault=my-vault;version=my-version", publicOptions}, "my-vault", "my-key", "my-version", "vault.azure.net", false, false},
+		{"ok no version", args{"azurekms:name=my-key;vault=my-vault", publicOptions}, "my-vault", "my-key", "", "vault.azure.net", false, false},
+		{"ok hsm", args{"azurekms:name=my-key;vault=my-vault?hsm=true", sovereignOptions}, "my-vault", "my-key", "", "vault.usgovcloudapi.net", true, false},
+		{"ok hsm false", args{"azurekms:name=my-key;vault=my-vault?hsm=false", sovereignOptions}, "my-vault", "my-key", "", "vault.usgovcloudapi.net", false, false},
+		{"ok default vault", args{"azurekms:name=my-key?version=my-version", DefaultOptions{Vault: "my-vault", Environment: azure.PublicCloud}}, "my-vault", "my-key", "my-version", "vault.azure.net", false, false},
+		{"ok default hsm", args{"azurekms:name=my-key;vault=my-vault?version=my-version", DefaultOptions{Vault: "other-vault", ProtectionLevel: apiv1.HSM, Environment: azure.PublicCloud}}, "my-vault", "my-key", "my-version", "vault.azure.net", true, false},
+		{"fail scheme", args{"azure:name=my-key;vault=my-vault", noOptions}, "", "", "", "", false, true},
+		{"fail parse uri", args{"azurekms:name=%ZZ;vault=my-vault", noOptions}, "", "", "", "", false, true},
+		{"fail no name", args{"azurekms:vault=my-vault", noOptions}, "", "", "", "", false, true},
+		{"fail empty name", args{"azurekms:name=;vault=my-vault", noOptions}, "", "", "", "", false, true},
+		{"fail no vault", args{"azurekms:name=my-key", noOptions}, "", "", "", "", false, true},
+		{"fail empty vault", args{"azurekms:name=my-key;vault=", noOptions}, "", "", "", "", false, true},
+		{"fail empty", args{"", noOptions}, "", "", "", "", false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotVault, gotName, gotVersion, gotHsm, err := parseKeyName(tt.args.rawURI, tt.args.defaults)
+			gotVault, gotName, gotVersion, gotDNSSuffix, gotHsm, err := parseKeyName(tt.args.rawURI, tt.args.defaults)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseKeyName() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -90,6 +94,9 @@ func Test_parseKeyName(t *testing.T) {
 			}
 			if gotVersion != tt.wantVersion {
 				t.Errorf("parseKeyName() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("parseKeyName() gotDNSSuffix = %v, want %v", gotDNSSuffix, tt.wantDNSSuffix)
 			}
 			if gotHsm != tt.wantHsm {
 				t.Errorf("parseKeyName() gotHsm = %v, want %v", gotHsm, tt.wantHsm)

--- a/kms/azurekms/utils_test.go
+++ b/kms/azurekms/utils_test.go
@@ -27,7 +27,10 @@ func Test_getKeyName(t *testing.T) {
 		want string
 	}{
 		{"ok", args{"my-vault", "my-key", getBundle("https://my-vault.vault.azure.net/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault?version=my-version"},
-		{"ok default", args{"my-vault", "my-key", getBundle("https://my-vault.foo.net/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault"},
+		{"ok usgov", args{"my-vault", "my-key", getBundle("https://my-vault.vault.usgovcloudapi.net/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault?version=my-version"},
+		{"ok china", args{"my-vault", "my-key", getBundle("https://my-vault.vault.azure.cn/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault?version=my-version"},
+		{"ok german", args{"my-vault", "my-key", getBundle("https://my-vault.vault.microsoftazure.de/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault?version=my-version"},
+		{"ok other", args{"my-vault", "my-key", getBundle("https://my-vault.foo.net/keys/my-key/my-version")}, "azurekms:name=my-key;vault=my-vault?version=my-version"},
 		{"ok too short", args{"my-vault", "my-key", getBundle("https://my-vault.vault.azure.net/keys/my-version")}, "azurekms:name=my-key;vault=my-vault"},
 		{"ok too long", args{"my-vault", "my-key", getBundle("https://my-vault.vault.azure.net/keys/my-key/my-version/sign")}, "azurekms:name=my-key;vault=my-vault"},
 		{"ok nil key", args{"my-vault", "my-key", keyvault.KeyBundle{}}, "azurekms:name=my-key;vault=my-vault"},


### PR DESCRIPTION
### Description

This commit adds support US Government, China, and German Cloud environments.

A new URI parameter has been introduced to define the Azure environment. If that parameter is not set or it is set to public, the public cloud will be used.

Fixes smallstep/certificates#1276
