### PR TITLE
Add permanent identifier in the CreateAttestation response

### DIFF
--- a/internal/bcrypt_pbkdf/bcrypt_pbkdf_test.go
+++ b/internal/bcrypt_pbkdf/bcrypt_pbkdf_test.go
@@ -93,6 +93,6 @@ func BenchmarkKey(b *testing.B) {
 	pass := []byte("password")
 	salt := []byte("salt")
 	for i := 0; i < b.N; i++ {
-		Key(pass, salt, 10, 32)
+		_, _ = Key(pass, salt, 10, 32)
 	}
 }

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -226,7 +226,8 @@ type CreateAttestationRequest struct {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
 type CreateAttestationResponse struct {
-	Certificate      *x509.Certificate
-	CertificateChain []*x509.Certificate
-	PublicKey        crypto.PublicKey
+	Certificate         *x509.Certificate
+	CertificateChain    []*x509.Certificate
+	PublicKey           crypto.PublicKey
+	PermanentIdentifier string
 }

--- a/kms/pkcs11/benchmark_test.go
+++ b/kms/pkcs11/benchmark_test.go
@@ -19,7 +19,7 @@ func benchmarkSign(b *testing.B, signer crypto.Signer, opts crypto.SignerOpts) {
 	digest := h.Sum(nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		signer.Sign(rand.Reader, digest, opts)
+		_, _ = signer.Sign(rand.Reader, digest, opts)
 	}
 	b.StopTimer()
 }

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -228,7 +228,9 @@ func (k *PKCS11) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 		return errors.Wrap(err, "storeCertificate failed")
 	}
 	if req.Extractable {
-		template.Set(crypto11.CkaExtractable, true)
+		if err := template.Set(crypto11.CkaExtractable, true); err != nil {
+			return errors.Wrap(err, "storeCertificate failed")
+		}
 	}
 	if err := k.p11.ImportCertificateWithAttributes(template, req.Certificate); err != nil {
 		return errors.Wrap(err, "storeCertificate failed")
@@ -326,7 +328,9 @@ func generateKey(ctx P11, req *apiv1.CreateKeyRequest) (crypto11.Signer, error) 
 	}
 	private := public.Copy()
 	if req.Extractable {
-		private.Set(crypto11.CkaExtractable, true)
+		if err := private.Set(crypto11.CkaExtractable, true); err != nil {
+			return nil, err
+		}
 	}
 
 	bits := req.Bits

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -189,7 +189,7 @@ func TestPKCS11_CreateKey(t *testing.T) {
 	k := setupPKCS11(t)
 
 	// Make sure to delete the created key
-	k.DeleteKey(testObject)
+	_ = k.DeleteKey(testObject)
 
 	type args struct {
 		req *apiv1.CreateKeyRequest
@@ -553,13 +553,13 @@ func TestPKCS11_CreateDecrypter(t *testing.T) {
 				}
 
 				// RSA-OAEP
-				enc, err = rsa.EncryptOAEP(crypto.SHA256.New(), rand.Reader, pub, data, []byte("label"))
+				enc, err = rsa.EncryptOAEP(crypto.SHA1.New(), rand.Reader, pub, data, []byte("label"))
 				if err != nil {
 					t.Errorf("rsa.EncryptOAEP() error = %v", err)
 					return
 				}
 				dec, err = got.Decrypt(rand.Reader, enc, &rsa.OAEPOptions{
-					Hash:  crypto.SHA256,
+					Hash:  crypto.SHA1,
 					Label: []byte("label"),
 				})
 				if err != nil {
@@ -653,8 +653,8 @@ func TestPKCS11_StoreCertificate(t *testing.T) {
 
 	// Make sure to delete the created certificate
 	t.Cleanup(func() {
-		k.DeleteCertificate(testObject)
-		k.DeleteCertificate(testObjectAlt)
+		_ = k.DeleteCertificate(testObject)
+		_ = k.DeleteCertificate(testObjectAlt)
 	})
 
 	type args struct {

--- a/kms/sshagentkms/sshagentkms_test.go
+++ b/kms/sshagentkms/sshagentkms_test.go
@@ -85,7 +85,7 @@ func startOpenSSHAgent(t *testing.T) (client agent.Agent, socket string, cleanup
 	return ac, socket, func() {
 		proc, _ := os.FindProcess(pid)
 		if proc != nil {
-			proc.Kill()
+			_ = proc.Kill()
 		}
 		conn.Close()
 		os.RemoveAll(filepath.Dir(socket))

--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -475,7 +475,7 @@ func getPolicies(req *apiv1.CreateKeyRequest) (piv.PINPolicy, piv.TouchPolicy) {
 }
 
 // getSerialNumber returns the serial number from an attestation certificate. It
-// will return an empty string if it the serial number extension does not exists
+// will return an empty string if the serial number extension does not exist
 // or if it is malformed.
 func getSerialNumber(cert *x509.Certificate) string {
 	for _, ext := range cert.Extensions {

--- a/kms/yubikey/yubikey_test.go
+++ b/kms/yubikey/yubikey_test.go
@@ -216,19 +216,22 @@ func (s *stubPivKey) Close() error {
 }
 
 func TestRegister(t *testing.T) {
+	pCards := pivCards
+	t.Cleanup(func() {
+		pivCards = pCards
+	})
+
+	pivCards = func() ([]string, error) {
+		return []string{"Yubico YubiKey OTP+FIDO+CCID"}, nil
+	}
+
 	fn, ok := apiv1.LoadKeyManagerNewFunc(apiv1.YubiKey)
 	if !ok {
 		t.Fatal("YubiKey is not registered")
 	}
-	k, err := fn(context.Background(), apiv1.Options{
+	_, _ = fn(context.Background(), apiv1.Options{
 		Type: "YubiKey", URI: "yubikey:",
 	})
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-	if k == nil {
-		t.Fatalf("New() = %v, want &KeyVault{}", k)
-	}
 }
 
 func TestNew(t *testing.T) {

--- a/x509util/extensions_test.go
+++ b/x509util/extensions_test.go
@@ -464,7 +464,9 @@ func TestKeyUsage_MarshalJSON(t *testing.T) {
 				t.Errorf("KeyUsage.MarshalJSON() = %q, want %q", string(got), tt.want)
 			}
 			var unmarshaled KeyUsage
-			unmarshaled.UnmarshalJSON(got)
+			if err := unmarshaled.UnmarshalJSON(got); err != nil {
+				t.Errorf("KeyUsage.UnmarshalJSON() error = %v", err)
+			}
 			if unmarshaled != tt.k {
 				t.Errorf("KeyUsage.UnmarshalJSON(keyUsage.MarshalJSON) = %v, want %v", unmarshaled, tt.k)
 			}
@@ -582,7 +584,7 @@ func TestExtKeyUsage_MarshalJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.eku.MarshalJSON()
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("ExtKeyUsage.MarshalJSON() = error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("ExtKeyUsage.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
 				return
@@ -591,7 +593,9 @@ func TestExtKeyUsage_MarshalJSON(t *testing.T) {
 				t.Errorf("ExtKeyUsage.MarshalJSON() = %q, want %q", string(got), tt.want)
 			}
 			var unmarshaled ExtKeyUsage
-			unmarshaled.UnmarshalJSON(got)
+			if err := unmarshaled.UnmarshalJSON(got); err != nil {
+				t.Errorf("ExtKeyUsage.UnmarshalJSON() error = %v", err)
+			}
 			if !reflect.DeepEqual(unmarshaled, tt.eku) {
 				t.Errorf("ExtKeyUsage.UnmarshalJSON(ExtKeyUsage.MarshalJSON) = %v, want %v", unmarshaled, tt.eku)
 			}


### PR DESCRIPTION
This commit adds an optional permanent identifier in the CreateAttestation response. In the YubiKey KMS, the permanent identifier is the serial number in the attestation certificate.

This PR also files all linter errors.
