### PR TITLE
Add support for asn1 methods in X509 templates

### DIFF
--- a/pemutil/pkcs8.go
+++ b/pemutil/pkcs8.go
@@ -313,7 +313,7 @@ func EncryptPKCS8PrivateKey(rand io.Reader, data, password []byte, alg x509.PEMC
 	}
 	enc.CryptBlocks(encrypted, encrypted)
 
-	// Build encrypted ans1 data
+	// Build encrypted asn1 data
 	pki := encryptedPrivateKeyInfo{
 		Algo: encryptedlAlgorithmIdentifier{
 			Algorithm: oidPBES2,

--- a/x509util/extensions.go
+++ b/x509util/extensions.go
@@ -126,7 +126,7 @@ type asn1PermanentIdentifier struct {
 	Assigner        asn1.ObjectIdentifier `asn1:"optional"`
 }
 
-func (p *PermanentIdentifier) ans1Type() asn1PermanentIdentifier {
+func (p *PermanentIdentifier) asn1Type() asn1PermanentIdentifier {
 	return asn1PermanentIdentifier{
 		IdentifierValue: p.Identifier,
 		Assigner:        asn1.ObjectIdentifier(p.Assigner),
@@ -154,7 +154,7 @@ type asn1HardwareModuleName struct {
 	SerialNumber []byte `asn1:"tag:4"`
 }
 
-func (h *HardwareModuleName) ans1Type() asn1HardwareModuleName {
+func (h *HardwareModuleName) asn1Type() asn1HardwareModuleName {
 	return asn1HardwareModuleName{
 		Type:         asn1.ObjectIdentifier(h.Type),
 		SerialNumber: h.SerialNumber,
@@ -350,7 +350,7 @@ func (s SubjectAlternativeName) RawValue() (asn1.RawValue, error) {
 			v.Identifier = s.Value
 		default: // continue, both identifierValue and assigner are optional
 		}
-		otherName, err := marshalOtherName(oidPermanentIdentifier, v.ans1Type())
+		otherName, err := marshalOtherName(oidPermanentIdentifier, v.asn1Type())
 		if err != nil {
 			return zero, errors.Wrap(err, "error marshaling PermanentIdentifier SAN")
 		}
@@ -363,7 +363,7 @@ func (s SubjectAlternativeName) RawValue() (asn1.RawValue, error) {
 		if err := json.Unmarshal(s.ASN1Value, &v); err != nil {
 			return zero, errors.Wrap(err, "error unmarshaling HardwareModuleName SAN")
 		}
-		otherName, err := marshalOtherName(oidHardwareModuleNameIdentifier, v.ans1Type())
+		otherName, err := marshalOtherName(oidHardwareModuleNameIdentifier, v.asn1Type())
 		if err != nil {
 			return zero, errors.Wrap(err, "error marshaling HardwareModuleName SAN")
 		}
@@ -381,7 +381,7 @@ func (s SubjectAlternativeName) RawValue() (asn1.RawValue, error) {
 			return zero, errors.Wrap(err, "error marshaling DirectoryName SAN")
 		}
 		if bytes.Equal(rdn, emptyASN1Subject) {
-			return zero, errors.New("error parsing DirectoryName SAN: empty or malformed ans1Value")
+			return zero, errors.New("error parsing DirectoryName SAN: empty or malformed asn1Value")
 		}
 		return asn1.RawValue{
 			Class:      asn1.ClassContextSpecific,
@@ -463,7 +463,7 @@ func parseFieldParameters(str string) (p asn1Params) {
 		case "utc", "generalized":
 			p.Type = part
 			params = append(params, part)
-		// base64 encoded ans1 value
+		// base64 encoded asn1 value
 		case "raw":
 			p.Type = part
 		case "":
@@ -478,9 +478,9 @@ func parseFieldParameters(str string) (p asn1Params) {
 
 // marshalValue marshals the given value with the given params.
 //
-// The return value value can be any type depending on the OID ASN supports a great
-// number of formats, but Golang's ans1 package supports much fewer -- for now
-// support anything the golang asn1 marshaller supports.
+// The return value value can be any type depending on the OID. ASN supports a
+// great number of formats, but Golang's asn1 package supports much fewer -- for
+// now support anything the Golang asn1 marshaller supports.
 //
 // See https://www.openssl.org/docs/man1.0.2/man3/ASN1_generate_nconf.html
 func marshalValue(value, params string) ([]byte, error) {

--- a/x509util/extensions_test.go
+++ b/x509util/extensions_test.go
@@ -349,10 +349,19 @@ func TestSubjectAlternativeName_RawValue(t *testing.T) {
 		{"otherName printable", fields{"1.2.3.4", "printable:abc1234", nil}, asn1.RawValue{
 			FullBytes: append([]byte{160, 16, 6, 3, 42, 3, 4, 160, 9, 19, 7}, []byte("abc1234")...),
 		}, false},
+		{"otherName utc", fields{"1.2.3.4", "utc:2023-03-29T02:03:57Z", nil}, asn1.RawValue{
+			FullBytes: append([]byte{160, 22, 6, 3, 42, 3, 4, 160, 15, 23, 13}, []byte("230329020357Z")...),
+		}, false},
+		{"otherName generalizd", fields{"1.2.3.4", "generalized:2023-03-29T02:03:57Z", nil}, asn1.RawValue{
+			FullBytes: append([]byte{160, 24, 6, 3, 42, 3, 4, 160, 17, 24, 15}, []byte("20230329020357Z")...),
+		}, false},
 		{"otherName default", fields{"1.2.3.4", "foo:abc1234", nil}, asn1.RawValue{
 			FullBytes: append([]byte{160, 16, 6, 3, 42, 3, 4, 160, 9, 19, 7}, []byte("abc1234")...),
 		}, false},
 		{"otherName no type", fields{"1.2.3.4", "abc1234", nil}, asn1.RawValue{
+			FullBytes: append([]byte{160, 16, 6, 3, 42, 3, 4, 160, 9, 19, 7}, []byte("abc1234")...),
+		}, false},
+		{"otherName whitespaces", fields{"1.2.3.4", ",,printable:abc1234", nil}, asn1.RawValue{
 			FullBytes: append([]byte{160, 16, 6, 3, 42, 3, 4, 160, 9, 19, 7}, []byte("abc1234")...),
 		}, false},
 		{"fail dn", fields{"dn", "1234", nil}, asn1.RawValue{}, true},
@@ -387,6 +396,8 @@ func TestSubjectAlternativeName_RawValue(t *testing.T) {
 		{"fail otherName ia5", fields{"1.2.3.4", "ia5:nötia5", nil}, asn1.RawValue{}, true},
 		{"fail otherName numeric", fields{"1.2.3.4", "numeric:abc", nil}, asn1.RawValue{}, true},
 		{"fail otherName printable", fields{"1.2.3.4", "printable:nötprintable", nil}, asn1.RawValue{}, true},
+		{"fail otherName utc", fields{"1.2.3.4", "utc:2023", nil}, asn1.RawValue{}, true},
+		{"fail otherName generalized", fields{"1.2.3.4", "generalized:2023-12-12", nil}, asn1.RawValue{}, true},
 		{"fail otherName default", fields{"1.2.3.4", "foo:nötprintable", nil}, asn1.RawValue{}, true},
 		{"fail otherName no type", fields{"1.2.3.4", "nötprintable", nil}, asn1.RawValue{}, true},
 	}

--- a/x509util/options.go
+++ b/x509util/options.go
@@ -41,14 +41,10 @@ func WithTemplate(text string, data TemplateData) Option {
 		terr := new(TemplateError)
 		funcMap := templates.GetFuncMap(&terr.Message)
 		// asn1 methods
-		funcMap["asn1enc"] = asn1Encode
+		funcMap["asn1Enc"] = asn1Encode
 		funcMap["asn1Marshal"] = asn1Marshal
 		funcMap["asn1Seq"] = asn1Sequence
 		funcMap["asn1Set"] = asn1Set
-		funcMap["mustASN1Enc"] = mustASN1Encode
-		funcMap["mustASN1Marshal"] = mustASN1Marshal
-		funcMap["mustASN1Seq"] = mustASN1Sequence
-		funcMap["mustASN1Set"] = mustASN1Set
 
 		// Parse template
 		tmpl, err := template.New("template").Funcs(funcMap).Parse(text)
@@ -96,39 +92,7 @@ func WithTemplateFile(path string, data TemplateData) Option {
 	}
 }
 
-func asn1Encode(str string) string {
-	b64, err := mustASN1Encode(str)
-	if err != nil {
-		return err.Error()
-	}
-	return b64
-}
-
-func asn1Marshal(v interface{}, params ...string) string {
-	b64, err := mustASN1Marshal(v, params...)
-	if err != nil {
-		return err.Error()
-	}
-	return b64
-}
-
-func asn1Sequence(b64enc ...string) string {
-	b64, err := mustASN1Sequence(b64enc...)
-	if err != nil {
-		return err.Error()
-	}
-	return b64
-}
-
-func asn1Set(b64enc ...string) string {
-	b64, err := mustASN1Set(b64enc...)
-	if err != nil {
-		return err.Error()
-	}
-	return b64
-}
-
-func mustASN1Encode(str string) (string, error) {
+func asn1Encode(str string) (string, error) {
 	value, params := str, "printable"
 	if strings.Contains(value, sanTypeSeparator) {
 		params = strings.SplitN(value, sanTypeSeparator, 2)[0]
@@ -141,7 +105,7 @@ func mustASN1Encode(str string) (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
-func mustASN1Marshal(v interface{}, params ...string) (string, error) {
+func asn1Marshal(v interface{}, params ...string) (string, error) {
 	b, err := encoding_asn1.MarshalWithParams(v, strings.Join(params, ","))
 	if err != nil {
 		return "", err
@@ -149,7 +113,7 @@ func mustASN1Marshal(v interface{}, params ...string) (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
-func mustASN1Sequence(b64enc ...string) (string, error) {
+func asn1Sequence(b64enc ...string) (string, error) {
 	var builder cryptobyte.Builder
 	builder.AddASN1(asn1.SEQUENCE, func(child *cryptobyte.Builder) {
 		for _, s := range b64enc {
@@ -168,7 +132,7 @@ func mustASN1Sequence(b64enc ...string) (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
-func mustASN1Set(b64enc ...string) (string, error) {
+func asn1Set(b64enc ...string) (string, error) {
 	var builder cryptobyte.Builder
 	builder.AddASN1(asn1.SET, func(child *cryptobyte.Builder) {
 		for _, s := range b64enc {

--- a/x509util/options.go
+++ b/x509util/options.go
@@ -40,11 +40,11 @@ func WithTemplate(text string, data TemplateData) Option {
 		terr := new(TemplateError)
 		funcMap := templates.GetFuncMap(&terr.Message)
 		// asn1 methods
-		funcMap["asn1Encode"] = asn1Encode
-		funcMap["asn1Sequence"] = asn1Sequence
+		funcMap["asn1enc"] = asn1Encode
+		funcMap["asn1Seq"] = asn1Sequence
 		funcMap["asn1Set"] = asn1Set
-		funcMap["mustASN1Encode"] = mustASN1Encode
-		funcMap["mustASN1Sequence"] = mustASN1Sequence
+		funcMap["mustASN1Enc"] = mustASN1Encode
+		funcMap["mustASN1Seq"] = mustASN1Sequence
 		funcMap["mustASN1Set"] = mustASN1Set
 
 		// Parse template

--- a/x509util/options_test.go
+++ b/x509util/options_test.go
@@ -56,8 +56,8 @@ func TestWithTemplate(t *testing.T) {
 {{- end }}
 	"extKeyUsage": ["serverAuth", "clientAuth"],
 	"extensions": [
-		{"type": "1.2.3.4", "value": {{ asn1Encode (first .Insecure.CR.DNSNames) | toJson }},
-		{"type": "1.2.3.5", "value": {{ asn1Sequence (asn1Encode (first .Insecure.CR.DNSNames)) (asn1Encode "int:123456") | toJson }},
+		{"id": "1.2.3.4", "value": {{ asn1enc (first .Insecure.CR.DNSNames) | toJson }},
+		{"id": "1.2.3.5", "value": {{ asn1Seq (asn1enc (first .Insecure.CR.DNSNames)) (asn1enc "int:123456") | toJson }},
 	]
 }`
 
@@ -156,8 +156,8 @@ func TestWithTemplate(t *testing.T) {
 	"keyUsage": ["digitalSignature"],
 	"extKeyUsage": ["serverAuth", "clientAuth"],
 	"extensions": [
-		{"type": "1.2.3.4", "value": "Ewdmb28uY29t",
-		{"type": "1.2.3.5", "value": "MA4TB2Zvby5jb20CAwHiQA==",
+		{"id": "1.2.3.4", "value": "Ewdmb28uY29t",
+		{"id": "1.2.3.5", "value": "MA4TB2Zvby5jb20CAwHiQA==",
 	]
 }`),
 		}, false},

--- a/x509util/options_test.go
+++ b/x509util/options_test.go
@@ -9,11 +9,11 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base64"
-	"fmt"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func createRSACertificateRequest(t *testing.T, bits int, commonName string, sans []string) (*x509.CertificateRequest, crypto.Signer) {
@@ -56,10 +56,10 @@ func TestWithTemplate(t *testing.T) {
 {{- end }}
 	"extKeyUsage": ["serverAuth", "clientAuth"],
 	"extensions": [
-		{"id": "1.2.3.4", "value": {{ asn1enc (first .Insecure.CR.DNSNames) | toJson }}},
+		{"id": "1.2.3.4", "value": {{ asn1Enc (first .Insecure.CR.DNSNames) | toJson }}},
 		{"id": "1.2.3.5", "value": {{ asn1Marshal (first .Insecure.CR.DNSNames) | toJson }}},
-		{"id": "1.2.3.6", "value": {{ asn1Seq (asn1enc (first .Insecure.CR.DNSNames)) (asn1enc "int:123456") | toJson }}},
-		{"id": "1.2.3.7", "value": {{ asn1Set (asn1Marshal (first .Insecure.CR.DNSNames) "utf8") (asn1enc "int:123456") | toJson }}}
+		{"id": "1.2.3.6", "value": {{ asn1Seq (asn1Enc (first .Insecure.CR.DNSNames)) (asn1Enc "int:123456") | toJson }}},
+		{"id": "1.2.3.7", "value": {{ asn1Set (asn1Marshal (first .Insecure.CR.DNSNames) "utf8") (asn1Enc "int:123456") | toJson }}}
 	]
 }`
 
@@ -301,34 +301,36 @@ func mustMarshal(t *testing.T, value interface{}, params string) string {
 func Test_asn1Encode(t *testing.T) {
 	now := time.Now().UTC()
 
-	_, timeErr := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "not-a-time")
-	timeErr = fmt.Errorf("invalid utc value: %w", timeErr)
-
 	type args struct {
 		str string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
-		{"ok", args{"string"}, mustMarshal(t, "string", "printable")},
-		{"ok explicit", args{"explicit:string"}, mustMarshal(t, "string", "printable,explicit")},
-		{"ok printable", args{"printable:string"}, mustMarshal(t, "string", "printable")},
-		{"ok printable explicit", args{"printable,explicit:string"}, mustMarshal(t, "string", "printable,explicit")},
-		{"ok ia5", args{"ia5:string"}, mustMarshal(t, "string", "ia5")},
-		{"ok utf8", args{"utf8:string"}, mustMarshal(t, "string", "utf8")},
-		{"ok utc", args{"utc:" + now.String()}, mustMarshal(t, now, "utc")},
-		{"ok generalized", args{"generalized:" + now.Format(time.RFC3339)}, mustMarshal(t, now, "generalized")},
-		{"ok int", args{"int:1234"}, mustMarshal(t, 1234, "")},
-		{"ok numeric", args{"numeric:1234"}, mustMarshal(t, "1234", "numeric")},
-		{"ok raw", args{"raw:" + mustMarshal(t, 1234, "")}, mustMarshal(t, 1234, "")},
-		{"fail numeric", args{"numeric:not-a-number"}, "invalid numeric value"},
-		{"fail time", args{"utc:not-a-time"}, timeErr.Error()},
+		{"ok", args{"string"}, mustMarshal(t, "string", "printable"), false},
+		{"ok explicit", args{"explicit:string"}, mustMarshal(t, "string", "printable,explicit"), false},
+		{"ok printable", args{"printable:string"}, mustMarshal(t, "string", "printable"), false},
+		{"ok printable explicit", args{"printable,explicit:string"}, mustMarshal(t, "string", "printable,explicit"), false},
+		{"ok ia5", args{"ia5:string"}, mustMarshal(t, "string", "ia5"), false},
+		{"ok utf8", args{"utf8:string"}, mustMarshal(t, "string", "utf8"), false},
+		{"ok utc", args{"utc:" + now.String()}, mustMarshal(t, now, "utc"), false},
+		{"ok generalized", args{"generalized:" + now.Format(time.RFC3339)}, mustMarshal(t, now, "generalized"), false},
+		{"ok int", args{"int:1234"}, mustMarshal(t, 1234, ""), false},
+		{"ok numeric", args{"numeric:1234"}, mustMarshal(t, "1234", "numeric"), false},
+		{"ok raw", args{"raw:" + mustMarshal(t, 1234, "")}, mustMarshal(t, 1234, ""), false},
+		{"fail numeric", args{"numeric:not-a-number"}, "", true},
+		{"fail time", args{"utc:not-a-time"}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := asn1Encode(tt.args.str); got != tt.want {
+			got, err := asn1Encode(tt.args.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("asn1Encode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
 				t.Errorf("asn1Encode() = %v, want %v", got, tt.want)
 			}
 		})
@@ -336,29 +338,32 @@ func Test_asn1Encode(t *testing.T) {
 }
 
 func Test_asn1Marshal(t *testing.T) {
-	_, numericErr := asn1.MarshalWithParams("string", "numeric")
-
 	now := time.Now()
 	type args struct {
 		v      interface{}
 		params []string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
-		{"ok printable", args{"string", nil}, mustMarshal(t, "string", "printable")},
-		{"ok utf8", args{"string", []string{"utf8"}}, mustMarshal(t, "string", "utf8")},
-		{"ok int", args{1234, nil}, mustMarshal(t, 1234, "")},
-		{"ok time", args{now, nil}, mustMarshal(t, now, "utc")},
-		{"ok seq", args{[]any{"string", 1234}, nil}, mustMarshal(t, []any{"string", 1234}, "")},
-		{"ok set", args{[]any{"string", 1234}, []string{"set"}}, mustMarshal(t, []any{"string", 1234}, "set")},
-		{"fail numeric", args{"string", []string{"numeric"}}, numericErr.Error()},
+		{"ok printable", args{"string", nil}, mustMarshal(t, "string", "printable"), false},
+		{"ok utf8", args{"string", []string{"utf8"}}, mustMarshal(t, "string", "utf8"), false},
+		{"ok int", args{1234, nil}, mustMarshal(t, 1234, ""), false},
+		{"ok time", args{now, nil}, mustMarshal(t, now, "utc"), false},
+		{"ok seq", args{[]any{"string", 1234}, nil}, mustMarshal(t, []any{"string", 1234}, ""), false},
+		{"ok set", args{[]any{"string", 1234}, []string{"set"}}, mustMarshal(t, []any{"string", 1234}, "set"), false},
+		{"fail numeric", args{"string", []string{"numeric"}}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := asn1Marshal(tt.args.v, tt.args.params...); got != tt.want {
+			got, err := asn1Marshal(tt.args.v, tt.args.params...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("asn1Marshal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
 				t.Errorf("asn1Marshal() = %v, want %v", got, tt.want)
 			}
 		})
@@ -376,25 +381,38 @@ func Test_asn1Sequence(t *testing.T) {
 		Set    set `asn1:"set"`
 	}
 
-	_, err := strconv.Atoi("string")
-	err = fmt.Errorf("invalid int value: %w", err)
-	_, err = base64.StdEncoding.DecodeString(err.Error())
+	b64String, err := asn1Encode("string")
+	require.NoError(t, err)
+
+	b64Int, err := asn1Encode("int:1234")
+	require.NoError(t, err)
+
+	b64Time, err := asn1Encode("utc:" + now.String())
+	require.NoError(t, err)
+
+	b64Set, err := asn1Set(b64Int, b64Time)
+	require.NoError(t, err)
 
 	type args struct {
 		b64enc []string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
-		{"ok", args{[]string{asn1Encode("string"), asn1Encode("int:1234")}}, mustMarshal(t, []any{"string", 1234}, "sequence")},
-		{"ok complex", args{[]string{asn1Encode("string"), asn1Set(asn1Encode("int:1234"), asn1Encode("utc:"+now.String()))}}, mustMarshal(t, complexWithSet{"string", set{1234, now}}, "")},
-		{"fail", args{[]string{asn1Encode("string"), asn1Encode("int:string")}}, err.Error()},
+		{"ok", args{[]string{b64String, b64Int}}, mustMarshal(t, []any{"string", 1234}, "sequence"), false},
+		{"ok complex", args{[]string{b64String, b64Set}}, mustMarshal(t, complexWithSet{"string", set{1234, now}}, ""), false},
+		{"fail", args{[]string{b64String, "bad-base-64"}}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := asn1Sequence(tt.args.b64enc...); got != tt.want {
+			got, err := asn1Sequence(tt.args.b64enc...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("asn1Sequence() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
 				t.Errorf("asn1Sequence() = %v, want %v", got, tt.want)
 			}
 		})
@@ -409,25 +427,38 @@ func Test_asn1Set(t *testing.T) {
 		Sequence []any
 	}
 
-	_, err := strconv.Atoi("string")
-	err = fmt.Errorf("invalid int value: %w", err)
-	_, err = base64.StdEncoding.DecodeString(err.Error())
+	b64String, err := asn1Encode("string")
+	require.NoError(t, err)
+
+	b64Int, err := asn1Encode("int:1234")
+	require.NoError(t, err)
+
+	b64Time, err := asn1Encode("utc:" + now.String())
+	require.NoError(t, err)
+
+	b64Sequence, err := asn1Sequence(b64Int, b64Time)
+	require.NoError(t, err)
 
 	type args struct {
 		b64enc []string
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		wantErr bool
 	}{
-		{"ok", args{[]string{asn1Encode("int:1234"), asn1Encode("string")}}, mustMarshal(t, []any{1234, "string"}, "set")},
-		{"ok complex", args{[]string{asn1Encode("string"), asn1Sequence(asn1Encode("int:1234"), asn1Encode("utc:"+now.String()))}}, mustMarshal(t, complexWithSequence{"string", []any{1234, now}}, "set")},
-		{"fail", args{[]string{asn1Encode("string"), asn1Encode("int:string")}}, err.Error()},
+		{"ok", args{[]string{b64Int, b64String}}, mustMarshal(t, []any{1234, "string"}, "set"), false},
+		{"ok complex", args{[]string{b64String, b64Sequence}}, mustMarshal(t, complexWithSequence{"string", []any{1234, now}}, "set"), false},
+		{"fail", args{[]string{b64String, "bad-base-64"}}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := asn1Set(tt.args.b64enc...); got != tt.want {
+			got, err := asn1Set(tt.args.b64enc...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("asn1Set() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
 				t.Errorf("asn1Set() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
### Description

This PR adds support for the following template functions:
* asn1enc, mustASN1Enc: given a string with or without a type, it encodes the ASN1 in base64.
* ans1Marshal, mustASN1Marshal: uses asn1.MarshalWithParams(), so it can support any type and options.
* asn1Seq, mustASN1Seq: given a list of base64(asn1) encoded strings, it builds a sequence of them, returning the base64 version of it.
* asn1Set, mustASN1Set: given a list of base64(asn1) encoded strings, it builds a set of them, returning the base64 version of it.

For example, you can build an extension like the following:
```go
{"id": "1.2.3.4", "value": {{ asn1Seq (asn1enc "YubiKey") (asn1enc "int:123456") | toJson }}}
```