### PR TITLE
Fix `EncryptPKCS8PrivateKey` output incompatibility with OpenSSL

### DIFF
--- a/pemutil/pkcs8.go
+++ b/pemutil/pkcs8.go
@@ -324,7 +324,8 @@ func EncryptPKCS8PrivateKey(rand io.Reader, data, password []byte, alg x509.PEMC
 						Salt:           salt,
 						IterationCount: PBKDF2Iterations,
 						PrfParam: prfParam{
-							Algo: oidHMACWithSHA256,
+							Algo:      oidHMACWithSHA256,
+							NullParam: asn1.NullRawValue,
 						},
 					},
 				},


### PR DESCRIPTION
Hi,

I've noticed an issue where the output of `EncryptPKCS8PrivateKey` is being rejected by OpenSSL. The `NullParam` value in the PRF parameters is left uninitialized, causing it to be marshalled as an end-of-contents marker rather than an ASN.1 null value, which is tripping up OpenSSL when it tries to parse the file:
```
    0:d=0  hl=3 l= 229 cons: SEQUENCE          
    3:d=1  hl=2 l=  96 cons:  SEQUENCE          
    5:d=2  hl=2 l=   9 prim:   OBJECT            :PBES2
   16:d=2  hl=2 l=  83 cons:   SEQUENCE          
   18:d=3  hl=2 l=  50 cons:    SEQUENCE          
   20:d=4  hl=2 l=   9 prim:     OBJECT            :PBKDF2
   31:d=4  hl=2 l=  37 cons:     SEQUENCE          
   33:d=5  hl=2 l=  16 prim:      OCTET STRING      [HEX DUMP]:81383AF9ED78EFD4552E2F6A0E0FF707
   51:d=5  hl=2 l=   3 prim:      INTEGER           :0186A0
   56:d=5  hl=2 l=  12 cons:      SEQUENCE          
   58:d=6  hl=2 l=   8 prim:       OBJECT            :hmacWithSHA256
   68:d=6  hl=2 l=   0 prim:       EOC               
   70:d=3  hl=2 l=  29 cons:    SEQUENCE          
   72:d=4  hl=2 l=   9 prim:     OBJECT            :aes-256-cbc
   83:d=4  hl=2 l=  16 prim:     OCTET STRING      [HEX DUMP]:4A2BAE713DD68B7D63504DA2A55AF60F
  101:d=1  hl=3 l= 128 prim:  OCTET STRING      [HEX DUMP]:E082EA51F55ECAE97997CCB...
```
```
$ openssl pkcs8 -in test.pem -passin pass:password
Error decrypting key
140575224706368:error:0D07809F:asn1 encoding routines:asn1_item_embed_d2i:unexpected eoc:../crypto/asn1/tasn_dec.c:360:Type=X509_ALGOR
140575224706368:error:0D08303A:asn1 encoding routines:asn1_template_noexp_d2i:nested asn1 error:../crypto/asn1/tasn_dec.c:646:Field=prf, Type=PBKDF2PARAM
140575224706368:error:0D0C706E:asn1 encoding routines:ASN1_item_unpack:decode error:../crypto/asn1/asn_pack.c:60:
140575224706368:error:060A4072:digital envelope routines:PKCS5_v2_PBKDF2_keyivgen:decode error:../crypto/evp/p5_crpt2.c:210:
140575224706368:error:06074078:digital envelope routines:EVP_PBE_CipherInit:keygen failure:../crypto/evp/evp_pbe.c:130:
140575224706368:error:23077073:PKCS12 routines:PKCS12_pbe_crypt:pkcs12 algor cipherinit error:../crypto/pkcs12/p12_decr.c:40:
140575224706368:error:2306A075:PKCS12 routines:PKCS12_item_decrypt_d2i:pkcs12 pbe crypt error:../crypto/pkcs12/p12_decr.c:93:
```
After the fix it looks like this:
```
    0:d=0  hl=3 l= 229 cons: SEQUENCE          
    3:d=1  hl=2 l=  96 cons:  SEQUENCE          
    5:d=2  hl=2 l=   9 prim:   OBJECT            :PBES2
   16:d=2  hl=2 l=  83 cons:   SEQUENCE          
   18:d=3  hl=2 l=  50 cons:    SEQUENCE          
   20:d=4  hl=2 l=   9 prim:     OBJECT            :PBKDF2
   31:d=4  hl=2 l=  37 cons:     SEQUENCE          
   33:d=5  hl=2 l=  16 prim:      OCTET STRING      [HEX DUMP]:ADCD4B75CEA73709290B2A6E29374D50
   51:d=5  hl=2 l=   3 prim:      INTEGER           :0186A0
   56:d=5  hl=2 l=  12 cons:      SEQUENCE          
   58:d=6  hl=2 l=   8 prim:       OBJECT            :hmacWithSHA256
   68:d=6  hl=2 l=   0 prim:       NULL              
   70:d=3  hl=2 l=  29 cons:    SEQUENCE          
   72:d=4  hl=2 l=   9 prim:     OBJECT            :aes-256-cbc
   83:d=4  hl=2 l=  16 prim:     OCTET STRING      [HEX DUMP]:51A5B06DDCA137013E47ECF717F21A48
  101:d=1  hl=3 l= 128 prim:  OCTET STRING      [HEX DUMP]:AA428E669400F88C1A91972907763DFC...
```
```
$ openssl pkcs8 -in test.pem -passin pass:password
-----BEGIN PRIVATE KEY-----
MHgCAQAwEAYHKoZIzj0CAQYFK4EEACEEYTBfAgEBBBywMyPdMrU43YvIVOuit5jf
uAdLNpF51myMePAIoTwDOgAEnMKG1vcSJcC++Z4eEby/S26yNiNWycxhGQdraTWX
ezEBcPm6U2/gAoQKeQ8UMcZ0F3p9detdXRo=
-----END PRIVATE KEY-----
```
Issue encountered on Go version 1.20.3 linux/amd64 with OpenSSL 1.1.1n.