### PR TITLE
Add automatic support for p11-kit

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -412,7 +412,7 @@ func findCertificate(ctx P11, rawuri string) (*x509.Certificate, error) {
 }
 
 // findP11KitProxy uses pkg-config to locate p11-kit-proxy.so
-func findP11KitProxy(ctx context.Context) string {
+var findP11KitProxy = func(ctx context.Context) string {
 	var out strings.Builder
 
 	// It should be more than enough even in constraint VMs

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -61,9 +61,9 @@ type PKCS11 struct {
 //   - pkcs11:module-path=/path/to/module.so;token=smallstep?pin-value=password
 //
 // The scheme is "pkcs11"; "token", "serial", or "slot-id" defines the
-// cryptographic device to use, "module-path" is the path of the PKCS#11 module
-// to use, it will default to the proxy module of the p11-kit project if none is
-// specified (p11-kit-proxy.so), "pin-value" provides the user's PIN, and
+// cryptographic device to use. "module-path" is the path of the PKCS#11 module
+// to use. It will default to the proxy module of the p11-kit project if none is
+// specified (p11-kit-proxy.so). "pin-value" provides the user's PIN, and
 // "pin-source" defines a file that contains the PIN.
 //
 // A cryptographic key or object is identified by its "id" or "object"
@@ -75,7 +75,7 @@ type PKCS11 struct {
 //
 //   - pkcs11:token=smallstep;id=0a10;object=ec-key?pin-value=password
 //   - pkcs11:token=smallstep;id=%0a%10?pin-source=/path/to/pin.txt
-//   - pkcs11:token=smallstep;object=ec=key?pin-value=password
+//   - pkcs11:token=smallstep;object=ec-key?pin-value=password
 func New(ctx context.Context, opts apiv1.Options) (*PKCS11, error) {
 	if opts.URI == "" {
 		return nil, errors.New("kms uri is required")
@@ -150,7 +150,7 @@ func init() {
 	})
 }
 
-// GetPublicKey returns the public key in stored in the given object.
+// GetPublicKey returns the public key stored in the object identified by the name URI.
 func (k *PKCS11) GetPublicKey(req *apiv1.GetPublicKeyRequest) (crypto.PublicKey, error) {
 	if req.Name == "" {
 		return nil, errors.New("getPublicKeyRequest 'name' cannot be empty")

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -74,7 +74,7 @@ type PKCS11 struct {
 // create a new key. The complete URI for a key looks like this:
 //
 //   - pkcs11:token=smallstep;id=0a10;object=ec-key?pin-value=password
-//   - pkcs11:token=smallstep;id=0a10?pin-source=/path/to/pin.txt
+//   - pkcs11:token=smallstep;id=%0a%10?pin-source=/path/to/pin.txt
 //   - pkcs11:token=smallstep;object=ec=key?pin-value=password
 func New(ctx context.Context, opts apiv1.Options) (*PKCS11, error) {
 	if opts.URI == "" {

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -76,7 +76,7 @@ func TestNew(t *testing.T) {
 		}}, k, false},
 		{"fail missing module", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
-		}}, k, false},
+		}}, nil, true},
 		{"fail missing pin", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
 			URI:  "pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=pkcs11-test",

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -157,7 +157,7 @@ func TestPKCS11_GetPublicKey(t *testing.T) {
 			Name: "pkcs11:id=7373;object=ecdsa-p256-key",
 		}}, &ecdsa.PublicKey{}, false},
 		{"ECDSA by id", args{&apiv1.GetPublicKeyRequest{
-			Name: "pkcs11:id=7373",
+			Name: "pkcs11:id=%73%73",
 		}}, &ecdsa.PublicKey{}, false},
 		{"ECDSA by label", args{&apiv1.GetPublicKeyRequest{
 			Name: "pkcs11:object=ecdsa-p256-key",
@@ -221,6 +221,15 @@ func TestPKCS11_CreateKey(t *testing.T) {
 			PublicKey: &ecdsa.PublicKey{},
 			CreateSignerRequest: apiv1.CreateSignerRequest{
 				SigningKey: testObject,
+			},
+		}, false},
+		{"default with percent URI", args{&apiv1.CreateKeyRequest{
+			Name: testObjectPercent,
+		}}, &apiv1.CreateKeyResponse{
+			Name:      testObjectPercent,
+			PublicKey: &ecdsa.PublicKey{},
+			CreateSignerRequest: apiv1.CreateSignerRequest{
+				SigningKey: testObjectPercent,
 			},
 		}, false},
 		{"RSA SHA256WithRSA", args{&apiv1.CreateKeyRequest{
@@ -428,7 +437,7 @@ func TestPKCS11_CreateSigner(t *testing.T) {
 			SigningKey: "pkcs11:id=7371;object=rsa-key",
 		}}, apiv1.SHA256WithRSA, crypto.SHA256, false},
 		{"RSA PSS", args{&apiv1.CreateSignerRequest{
-			SigningKey: "pkcs11:id=7372;object=rsa-pss-key",
+			SigningKey: "pkcs11:id=%73%72;object=rsa-pss-key",
 		}}, apiv1.SHA256WithRSAPSS, &rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthEqualsHash,
 			Hash:       crypto.SHA256,
@@ -437,7 +446,7 @@ func TestPKCS11_CreateSigner(t *testing.T) {
 			SigningKey: "pkcs11:id=7373;object=ecdsa-p256-key",
 		}}, apiv1.ECDSAWithSHA256, crypto.SHA256, false},
 		{"ECDSA P384", args{&apiv1.CreateSignerRequest{
-			SigningKey: "pkcs11:id=7374;object=ecdsa-p384-key",
+			SigningKey: "pkcs11:id=%73%74;object=ecdsa-p384-key",
 		}}, apiv1.ECDSAWithSHA384, crypto.SHA384, false},
 		{"ECDSA P521", args{&apiv1.CreateSignerRequest{
 			SigningKey: "pkcs11:id=7375;object=ecdsa-p521-key",
@@ -512,7 +521,7 @@ func TestPKCS11_CreateDecrypter(t *testing.T) {
 			DecryptionKey: "pkcs11:id=7371;object=rsa-key",
 		}}, false},
 		{"RSA PSS", args{&apiv1.CreateDecrypterRequest{
-			DecryptionKey: "pkcs11:id=7372;object=rsa-pss-key",
+			DecryptionKey: "pkcs11:id=%73%72;object=rsa-pss-key",
 		}}, false},
 		{"ECDSA P256", args{&apiv1.CreateDecrypterRequest{
 			DecryptionKey: "pkcs11:id=7373;object=ecdsa-p256-key",

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -74,7 +74,7 @@ func TestNew(t *testing.T) {
 			URI:  "pkcs11:token=pkcs11-test",
 			Pin:  "passowrd",
 		}}, k, false},
-		{"fail missing module", args{context.Background(), apiv1.Options{
+		{"fail missing uri", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
 		}}, nil, true},
 		{"fail missing pin", args{context.Background(), apiv1.Options{

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -26,10 +26,8 @@ import (
 
 func TestNew(t *testing.T) {
 	tmp0 := p11Configure
-	tmp1 := findP11KitProxy
 	t.Cleanup(func() {
 		p11Configure = tmp0
-		findP11KitProxy = tmp1
 	})
 
 	k := mustPKCS11(t)
@@ -43,21 +41,6 @@ func TestNew(t *testing.T) {
 		}
 		return k.p11, nil
 	}
-
-	findP11KitProxy = func(ctx context.Context) string {
-		select {
-		case <-ctx.Done():
-			return ""
-		default:
-			if fail, _ := ctx.Value("fail").(bool); fail {
-				return ""
-			}
-			return "/usr/local/lib/p11-kit-proxy.so"
-		}
-	}
-
-	canceledContext, cancel := context.WithCancel(context.Background())
-	cancel()
 
 	type args struct {
 		ctx  context.Context
@@ -91,15 +74,9 @@ func TestNew(t *testing.T) {
 			URI:  "pkcs11:token=pkcs11-test",
 			Pin:  "passowrd",
 		}}, k, false},
-		{"fail with missing module", args{context.WithValue(context.Background(), "fail", true), apiv1.Options{
+		{"fail missing module", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
-			URI:  "pkcs11:token=pkcs11-test",
-			Pin:  "passowrd",
-		}}, nil, true},
-		{"fail findP11KitProxy", args{canceledContext, apiv1.Options{
-			Type: "pkcs11",
-			URI:  "pkcs11:token=pkcs11-test?pin-value=password",
-		}}, nil, true},
+		}}, k, false},
 		{"fail missing pin", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
 			URI:  "pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=pkcs11-test",
@@ -857,32 +834,6 @@ func TestPKCS11_Close(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := k.Close(); (err != nil) != tt.wantErr {
 				t.Errorf("PKCS11.Close() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func Test_findP11KitProxy(t *testing.T) {
-	expected := findP11KitProxy(context.Background())
-
-	canceledContext, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	type args struct {
-		ctx context.Context
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{"expected", args{context.Background()}, expected},
-		{"fail", args{canceledContext}, ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := findP11KitProxy(tt.args.ctx); got != tt.want {
-				t.Errorf("findP11KitProxy() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/kms/pkcs11/setup_test.go
+++ b/kms/pkcs11/setup_test.go
@@ -18,6 +18,7 @@ import (
 var (
 	testModule        = ""
 	testObject        = "pkcs11:id=7370;object=test-name"
+	testObjectPercent = "pkcs11:id=%73%70;object=test-name"
 	testObjectAlt     = "pkcs11:id=7377;object=alt-test-name"
 	testObjectByID    = "pkcs11:id=7370"
 	testObjectByLabel = "pkcs11:object=test-name"
@@ -27,9 +28,9 @@ var (
 		Bits               int
 	}{
 		{"pkcs11:id=7371;object=rsa-key", apiv1.SHA256WithRSA, 2048},
-		{"pkcs11:id=7372;object=rsa-pss-key", apiv1.SHA256WithRSAPSS, DefaultRSASize},
+		{"pkcs11:id=%73%72;object=rsa-pss-key", apiv1.SHA256WithRSAPSS, DefaultRSASize},
 		{"pkcs11:id=7373;object=ecdsa-p256-key", apiv1.ECDSAWithSHA256, 0},
-		{"pkcs11:id=7374;object=ecdsa-p384-key", apiv1.ECDSAWithSHA384, 0},
+		{"pkcs11:id=%73%74;object=ecdsa-p384-key", apiv1.ECDSAWithSHA384, 0},
 		{"pkcs11:id=7375;object=ecdsa-p521-key", apiv1.ECDSAWithSHA512, 0},
 	}
 


### PR DESCRIPTION
### Description

This commit adds support to automatically use the p11-kit-proxy module on the PKCS#11 KMS if no other module has been specified.

Fixes #259

cc: @dwmw2
