### PR TITLE
Add UNIX socket TPM connection support

### DIFF
--- a/kms/tpmkms/tpmkms_simulator_test.go
+++ b/kms/tpmkms/tpmkms_simulator_test.go
@@ -75,8 +75,9 @@ func withSimulator(t *testing.T) tpmp.NewTPMOption {
 		err := sim.Close()
 		require.NoError(t, err)
 	})
-	sim = simulator.New()
-	err := sim.Open()
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	err = sim.Open()
 	require.NoError(t, err)
 	return tpmp.WithSimulator(sim)
 }

--- a/tpm/attestation/client_simulator_test.go
+++ b/tpm/attestation/client_simulator_test.go
@@ -47,8 +47,9 @@ func withSimulator(t *testing.T) tpm.NewTPMOption {
 		err := sim.Close()
 		require.NoError(t, err)
 	})
-	sim = simulator.New()
-	err := sim.Open()
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	err = sim.Open()
 	require.NoError(t, err)
 	return tpm.WithSimulator(sim)
 }

--- a/tpm/available/check.go
+++ b/tpm/available/check.go
@@ -1,0 +1,15 @@
+package available
+
+import (
+	"fmt"
+
+	"go.step.sm/crypto/tpm"
+)
+
+func Check(opts ...tpm.NewTPMOption) error {
+	t, err := tpm.New(opts...)
+	if err != nil {
+		return fmt.Errorf("failed creating TPM instance: %w", err)
+	}
+	return t.Available()
+}

--- a/tpm/internal/close/close.go
+++ b/tpm/internal/close/close.go
@@ -1,4 +1,4 @@
-package close
+package closer
 
 import (
 	"io"

--- a/tpm/internal/close/close.go
+++ b/tpm/internal/close/close.go
@@ -1,0 +1,7 @@
+package close
+
+import "io"
+
+func RWC(rwc io.ReadWriteCloser) error {
+	return closeRWC(rwc)
+}

--- a/tpm/internal/close/close.go
+++ b/tpm/internal/close/close.go
@@ -1,7 +1,15 @@
 package close
 
-import "io"
+import (
+	"io"
+
+	"github.com/smallstep/go-attestation/attest"
+)
 
 func RWC(rwc io.ReadWriteCloser) error {
 	return closeRWC(rwc)
+}
+
+func AttestTPM(t *attest.TPM, c *attest.OpenConfig) error {
+	return attestTPM(t, c)
 }

--- a/tpm/internal/close/close_others.go
+++ b/tpm/internal/close/close_others.go
@@ -7,6 +7,9 @@ import (
 	"io"
 
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/smallstep/go-attestation/attest"
+
+	"go.step.sm/crypto/tpm/internal/socket"
 )
 
 func closeRWC(rwc io.ReadWriteCloser) error {
@@ -14,4 +17,11 @@ func closeRWC(rwc io.ReadWriteCloser) error {
 		return nil // EmulatorReadWriteCloser automatically closes on every write/read cycle
 	}
 	return rwc.Close()
+}
+
+func attestTPM(t *attest.TPM, c *attest.OpenConfig) error {
+	if _, ok := c.CommandChannel.(*socket.CommandChannelWithoutMeasurementLog); ok {
+		return nil // backed by tpmutil.EmulatorReadWriteCloser; already closed
+	}
+	return t.Close()
 }

--- a/tpm/internal/close/close_others.go
+++ b/tpm/internal/close/close_others.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package close
+package closer
 
 import (
 	"io"

--- a/tpm/internal/close/close_others.go
+++ b/tpm/internal/close/close_others.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package close
+
+import (
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+func closeRWC(rwc io.ReadWriteCloser) error {
+	if _, ok := rwc.(*tpmutil.EmulatorReadWriteCloser); ok {
+		return nil // EmulatorReadWriteCloser automatically closes on every write/read cycle
+	}
+	return rwc.Close()
+}

--- a/tpm/internal/close/close_windows.go
+++ b/tpm/internal/close/close_windows.go
@@ -5,8 +5,14 @@ package close
 
 import (
 	"io"
+
+	"github.com/smallstep/go-attestation/attest"
 )
 
 func closeRWC(rwc io.ReadWriteCloser) error {
 	return rwc.Close()
+}
+
+func attestTPM(t *attest.TPM, _ *attest.OpenConfig) error {
+	return t.Close()
 }

--- a/tpm/internal/close/close_windows.go
+++ b/tpm/internal/close/close_windows.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package close
+package closer
 
 import (
 	"io"

--- a/tpm/internal/close/close_windows.go
+++ b/tpm/internal/close/close_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package close
+
+import (
+	"io"
+)
+
+func closeRWC(rwc io.ReadWriteCloser) error {
+	return rwc.Close()
+}

--- a/tpm/internal/open/open.go
+++ b/tpm/internal/open/open.go
@@ -1,6 +1,8 @@
 package open
 
-import "io"
+import (
+	"io"
+)
 
 func TPM(deviceName string) (io.ReadWriteCloser, error) {
 	return open(deviceName)

--- a/tpm/internal/socket/socket.go
+++ b/tpm/internal/socket/socket.go
@@ -1,11 +1,17 @@
 package socket
 
 import (
+	"errors"
 	"io"
 )
 
+var (
+	ErrNotAvailable = errors.New("socket not available")
+	ErrNotSupported = errors.New("connecting to a TPM using a UNIX socket is not supported on Windows")
+)
+
 func New(path string) (io.ReadWriteCloser, error) {
-	return new(path)
+	return newSocket(path)
 }
 
 type CommandChannelWithoutMeasurementLog struct {

--- a/tpm/internal/socket/socket.go
+++ b/tpm/internal/socket/socket.go
@@ -1,0 +1,17 @@
+package socket
+
+import (
+	"io"
+)
+
+func New(path string) (io.ReadWriteCloser, error) {
+	return new(path)
+}
+
+type CommandChannelWithoutMeasurementLog struct {
+	io.ReadWriteCloser
+}
+
+func (c *CommandChannelWithoutMeasurementLog) MeasurementLog() ([]byte, error) {
+	return nil, nil
+}

--- a/tpm/internal/socket/socket_others.go
+++ b/tpm/internal/socket/socket_others.go
@@ -10,15 +10,16 @@ import (
 	"github.com/google/go-tpm/tpmutil"
 )
 
-func new(path string) (io.ReadWriteCloser, error) {
+func newSocket(path string) (io.ReadWriteCloser, error) {
+	if path == "" {
+		return nil, ErrNotAvailable
+	}
 	fi, err := os.Stat(path)
 	if err != nil { // TODO(hs): handle specific errors here?
 		return nil, err
 	}
-
 	if fi.Mode()&os.ModeSocket != 0 {
 		return tpmutil.NewEmulatorReadWriteCloser(path), nil
 	}
-
-	return nil, nil
+	return nil, ErrNotAvailable
 }

--- a/tpm/internal/socket/socket_others.go
+++ b/tpm/internal/socket/socket_others.go
@@ -1,0 +1,24 @@
+//go:build !windows
+// +build !windows
+
+package socket
+
+import (
+	"io"
+	"os"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+func new(path string) (io.ReadWriteCloser, error) {
+	fi, err := os.Stat(path)
+	if err != nil { // TODO(hs): handle specific errors here?
+		return nil, err
+	}
+
+	if fi.Mode()&os.ModeSocket != 0 {
+		return tpmutil.NewEmulatorReadWriteCloser(path), nil
+	}
+
+	return nil, nil
+}

--- a/tpm/internal/socket/socket_windows.go
+++ b/tpm/internal/socket/socket_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package socket
+
+import (
+	"io"
+)
+
+func new(_ string) (io.ReadWriteCloser, error) {
+	return nil, errors.New("connecting to a TPM using a UNIX socket is not supported on Windows")
+}

--- a/tpm/internal/socket/socket_windows.go
+++ b/tpm/internal/socket/socket_windows.go
@@ -7,6 +7,6 @@ import (
 	"io"
 )
 
-func new(_ string) (io.ReadWriteCloser, error) {
-	return nil, errors.New("connecting to a TPM using a UNIX socket is not supported on Windows")
+func newSocket(_ string) (io.ReadWriteCloser, error) {
+	return nil, ErrNotSupported
 }

--- a/tpm/rand/rand_simulator_test.go
+++ b/tpm/rand/rand_simulator_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,11 +31,11 @@ func withSimulator(t *testing.T) tpm.NewTPMOption {
 	return tpm.WithSimulator(sim)
 }
 
-func withNewErrorSimulator(t *testing.T) tpm.NewTPMOption {
-	return func(t *tpm.TPM) error {
-		return errors.New("forced new error")
-	}
-}
+// func withNewErrorSimulator(t *testing.T) tpm.NewTPMOption {
+// 	return func(o *options) error {
+// 		return errors.New("forced new error")
+// 	}
+// }
 
 func TestNew(t *testing.T) {
 	r, err := New(withSimulator(t))
@@ -56,6 +55,6 @@ func TestNew(t *testing.T) {
 		require.Equal(t, 256, rsaKey.Size()) // 2048 bits; 256 bytes expected to have been read
 	}
 
-	_, err = New(withNewErrorSimulator(t))
-	require.Error(t, err)
+	// _, err = New(withNewErrorSimulator(t))
+	// require.Error(t, err)
 }

--- a/tpm/rand/rand_simulator_test.go
+++ b/tpm/rand/rand_simulator_test.go
@@ -31,12 +31,6 @@ func withSimulator(t *testing.T) tpm.NewTPMOption {
 	return tpm.WithSimulator(sim)
 }
 
-// func withNewErrorSimulator(t *testing.T) tpm.NewTPMOption {
-// 	return func(o *options) error {
-// 		return errors.New("forced new error")
-// 	}
-// }
-
 func TestNew(t *testing.T) {
 	r, err := New(withSimulator(t))
 	require.NoError(t, err)
@@ -54,7 +48,4 @@ func TestNew(t *testing.T) {
 	if assert.NotNil(t, rsaKey) {
 		require.Equal(t, 256, rsaKey.Size()) // 2048 bits; 256 bytes expected to have been read
 	}
-
-	// _, err = New(withNewErrorSimulator(t))
-	// require.Error(t, err)
 }

--- a/tpm/rand/rand_simulator_test.go
+++ b/tpm/rand/rand_simulator_test.go
@@ -25,8 +25,9 @@ func withSimulator(t *testing.T) tpm.NewTPMOption {
 		err := sim.Close()
 		require.NoError(t, err)
 	})
-	sim = simulator.New()
-	err := sim.Open()
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	err = sim.Open()
 	require.NoError(t, err)
 	return tpm.WithSimulator(sim)
 }

--- a/tpm/simulator/simulator_disabled.go
+++ b/tpm/simulator/simulator_disabled.go
@@ -11,12 +11,12 @@ import (
 type NoSimulator struct {
 }
 
-func New() Simulator {
-	return &NoSimulator{}
+func New() (Simulator, error) {
+	return &NoSimulator{}, errors.New("no simulator available")
 }
 
 func (s *NoSimulator) Open() error {
-	return errors.New("no simulator available")
+	return errors.New("cannot open: no simulator available")
 }
 
 func (s *NoSimulator) Close() error {

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -60,7 +60,6 @@ func WithStore(store storage.TPMStore) NewTPMOption {
 		if store == nil {
 			store = storage.BlackHole() // prevent nil storage; no persistence
 		}
-
 		o.store = store
 		return nil
 	}
@@ -127,7 +126,7 @@ func New(opts ...NewTPMOption) (*TPM, error) {
 		return nil, fmt.Errorf("invalid TPM options provided: %w", err)
 	}
 
-	tpm := &TPM{
+	return &TPM{
 		deviceName:     tpmOptions.deviceName,
 		attestConfig:   tpmOptions.attestConfig,
 		store:          tpmOptions.store,
@@ -135,9 +134,7 @@ func New(opts ...NewTPMOption) (*TPM, error) {
 		simulator:      tpmOptions.simulator,
 		commandChannel: tpmOptions.commandChannel,
 		options:        &tpmOptions,
-	}
-
-	return tpm, nil
+	}, nil
 }
 
 // Open readies the TPM for usage and marks it as being
@@ -291,6 +288,12 @@ func (t *TPM) close(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (t *TPM) Available() (err error) {
+	ctx := context.Background()
+	_, err = t.Info(ctx)
+	return
 }
 
 type validatableConfig interface {

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -291,8 +291,7 @@ func (t *TPM) close(ctx context.Context) error {
 }
 
 func (t *TPM) Available() (err error) {
-	ctx := context.Background()
-	_, err = t.Info(ctx)
+	_, err = t.Info(context.Background())
 	return
 }
 

--- a/tpm/tpm_simulator_test.go
+++ b/tpm/tpm_simulator_test.go
@@ -47,8 +47,9 @@ func withSimulator(t *testing.T) NewTPMOption {
 		err := sim.Close()
 		require.NoError(t, err)
 	})
-	sim = simulator.New()
-	err := sim.Open()
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	err = sim.Open()
 	require.NoError(t, err)
 	return WithSimulator(sim)
 }

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -37,9 +37,8 @@ var _ io.ReadWriteCloser = (*closeSimulator)(nil)
 
 func newOpenedTPM(t *testing.T) *TPM {
 	t.Helper()
-	tpm, err := New()
+	tpm, err := New(WithSimulator(&closeSimulator{}))
 	require.NoError(t, err)
-	tpm.simulator = &closeSimulator{}
 	err = tpm.open(context.Background())
 	require.NoError(t, err)
 	return tpm
@@ -47,11 +46,10 @@ func newOpenedTPM(t *testing.T) *TPM {
 
 func newCloseErrorTPM(t *testing.T) *TPM {
 	t.Helper()
-	tpm, err := New()
-	require.NoError(t, err)
-	tpm.simulator = &closeSimulator{
+	tpm, err := New(WithSimulator(&closeSimulator{
 		closeErr: errors.New("closeErr"),
-	}
+	}))
+	require.NoError(t, err)
 	err = tpm.open(context.Background())
 	require.NoError(t, err)
 	tpm.simulator = nil // required to skip returning when similator is configured


### PR DESCRIPTION
On Linux and macOS a connection can now be made to a TPM that's exposed on a UNIX socket. This shouldn't be used for production purposes, but can be useful for development and testing with a TPM simulator. The [tpmutil.EmulatorReadWriteCloser](https://pkg.go.dev/github.com/google/go-tpm/tpmutil#EmulatorReadWriteCloser) is used to create the connection with the simulated TPM. 

A UNIX socket TPM will only be used when the TPM is initialized with a device name that contains the path to a UNIX socket. If the TPM instance is initialized with a `tpm.CommandChannel` or `simulator.Simulator` directly, these will take precedence over the UNIX socket path.

Connecting to a TPM using a UNIX socket is not supported on Windows.