### PR TITLE
Add `AMZN` (AWS; NitroTPM) as known TPM manufacturer

### DIFF
--- a/tpm/manufacturer/manufacturers.go
+++ b/tpm/manufacturer/manufacturers.go
@@ -99,6 +99,9 @@ func init() {
 		// Also see https://github.com/fido-alliance/conformance-test-tools-resources/issues/537
 		"FIDO": "FIDO Alliance", // NOTE: FIDO is not the official ASCII representation
 
+		// Amazon Web Services; NitroTPM
+		"AMZN": "Amazon Web Services",
+
 		// Others
 		"PRLS": "Parallels Desktop",
 		"VMW":  "VMWare",


### PR DESCRIPTION
Before:

```console
$ sudo step tpm info
+------------------+--------------------------------------+
| Version          | TPM 2.0                              |
| Interface        | kernel-managed                       |
| Manufacturer     | unknown (AMZN, 414D5A4E, 1095588430) |
| Vendor Info      | NitroTPMv1.0                         |
| Firmware Version | 8217.4131                            |
+------------------+--------------------------------------+
```

After:

```console
$ sudo step tpm info
+------------------+--------------------------------------------------+
| Version          | TPM 2.0                                          |
| Interface        | kernel-managed                                   |
| Manufacturer     | Amazon Web Services (AMZN, 414D5A4E, 1095588430) |
| Vendor Info      | NitroTPMv1.0                                     |
| Firmware Version | 8217.4131                                        |
+------------------+--------------------------------------------------+
```