### PR TITLE
Return an error when AK certificate is expired

### DIFF
--- a/kms/tpmkms/errors.go
+++ b/kms/tpmkms/errors.go
@@ -1,0 +1,10 @@
+package tpmkms
+
+import "errors"
+
+var (
+	ErrIdentityCertificateUnavailable = errors.New("AK certificate not available")
+	ErrIdentityCertificateNotYetValid = errors.New("AK certificate not yet valid")
+	ErrIdentityCertificateExpired     = errors.New("AK certificate has expired")
+	ErrIdentityCertificateInvalid     = errors.New("AK certificate does not contain valid identity")
+)


### PR DESCRIPTION
This way a user of the package can try to obtain a new AK certificate when it has expired.

In addition to that, also return errors for other certificate state errors, such as not yet valid and it not being available.

