### PR TITLE
Add support for early renewal for AK identity certificates

### DIFF
--- a/kms/tpmkms/errors.go
+++ b/kms/tpmkms/errors.go
@@ -6,5 +6,6 @@ var (
 	ErrIdentityCertificateUnavailable = errors.New("AK certificate not available")
 	ErrIdentityCertificateNotYetValid = errors.New("AK certificate not yet valid")
 	ErrIdentityCertificateExpired     = errors.New("AK certificate has expired")
+	ErrIdentityCertificateIsExpiring  = errors.New("AK certificate will expire soon")
 	ErrIdentityCertificateInvalid     = errors.New("AK certificate does not contain valid identity")
 )

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -18,9 +18,10 @@ func TestNew(t *testing.T) {
 		want    *TPMKMS
 		wantErr bool
 	}{
-		{"ok/defaults", args{apiv1.Options{Type: "tpmkms"}}, &TPMKMS{}, false},
-		{"ok/uri", args{apiv1.Options{Type: "tpmkms", URI: "tpmkms:device=/dev/tpm0;storage-directory=/tmp/tpmstorage"}}, &TPMKMS{}, false},
+		{"ok/defaults", args{apiv1.Options{Type: "tpmkms"}}, &TPMKMS{identityEarlyRenewalEnabled: true, identityRenewalPeriodPercentage: 60}, false},
+		{"ok/uri", args{apiv1.Options{Type: "tpmkms", URI: "tpmkms:device=/dev/tpm0;storage-directory=/tmp/tpmstorage;renewal-percentage=70"}}, &TPMKMS{identityEarlyRenewalEnabled: true, identityRenewalPeriodPercentage: 70}, false},
 		{"fail/uri-scheme", args{apiv1.Options{Type: "tpmkms", URI: "tpmkmz://device=/dev/tpm0"}}, &TPMKMS{}, true},
+		{"fail/renewal-percentage-too-low", args{apiv1.Options{Type: "tpmkms", URI: "tpmkms:renewal-percentage=0"}}, &TPMKMS{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -32,6 +33,8 @@ func TestNew(t *testing.T) {
 
 			if assert.NotNil(t, got) {
 				assert.NotNil(t, got.tpm)
+				assert.Equal(t, tt.want.identityEarlyRenewalEnabled, got.identityEarlyRenewalEnabled)
+				assert.Equal(t, tt.want.identityRenewalPeriodPercentage, got.identityRenewalPeriodPercentage)
 			}
 		})
 	}

--- a/kms/uri/uri.go
+++ b/kms/uri/uri.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -113,6 +114,23 @@ func (u *URI) GetBool(key string) bool {
 		v = u.URL.Query().Get(key)
 	}
 	return strings.EqualFold(v, "true")
+}
+
+// GetInt returns the first integer value in the URI with the given key. It
+// returns nil if the field is not present or if the value can't be parsed
+// as an integer.
+func (u *URI) GetInt(key string) *int64 {
+	v := u.Values.Get(key)
+	if v == "" {
+		v = u.URL.Query().Get(key)
+	}
+	if v == "" {
+		return nil
+	}
+	if i, err := strconv.ParseInt(v, 10, 0); err == nil {
+		return &i
+	}
+	return nil
 }
 
 // GetEncoded returns the first value in the uri with the given key, it will

--- a/kms/uri/uri_test.go
+++ b/kms/uri/uri_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNew(t *testing.T) {
@@ -300,6 +302,40 @@ func TestURI_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.uri.String(); got != tt.want {
 				t.Errorf("URI.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURI_GetInt(t *testing.T) {
+	seventy := int64(70)
+	mustParse := func(s string) *URI {
+		u, err := Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name string
+		uri  *URI
+		args args
+		want *int64
+	}{
+		{"ok", mustParse("tpmkms:renewal-percentage=70"), args{"renewal-percentage"}, &seventy},
+		{"ok empty", mustParse("tpmkms:empty"), args{"renewal-percentage"}, nil},
+		{"ok non-integer", mustParse("tpmkms:renewal-percentage=not-an-integer"), args{"renewal-percentage"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.uri.GetInt(tt.args.key)
+			if tt.want != nil {
+				assert.Equal(t, *tt.want, *got)
+			} else {
+				assert.Nil(t, got)
 			}
 		})
 	}


### PR DESCRIPTION
To support early renewal of AK certificates as part of a call to `CreateAttestation` in `TPMKMS`, the KMS should detect if an AK certificate is still within a specific percentage of it its original lifetime. This PR adds support for this check and introduces two new KMS URI options that influence the behavior:

* `disable-early-renewal=true`: disables the early renewal check and thus won't return an error when the certificate hasn't actually expired yet.
* `renewal-percentage=<int>`: sets the percentage of the lifetime after which the AK certificate will be considered to expire soon, and renewal will thus be tried.