### PR TITLE
Add `PasswordPrompter` to decrypter and signer requests

### DIFF
--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -186,10 +186,8 @@ func (o *Options) GetType() (Type, error) {
 
 var ErrNonInteractivePasswordPrompt = errors.New("password required in non-interactive context")
 
-var NonInteractivePasswordPrompter = func() PasswordPrompter {
-	return func(s string) ([]byte, error) {
-		return nil, ErrNonInteractivePasswordPrompt
-	}
+var NonInteractivePasswordPrompter = func(s string) ([]byte, error) {
+	return nil, ErrNonInteractivePasswordPrompt
 }
 
 type PasswordPrompter func(s string) ([]byte, error)

--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -182,3 +183,13 @@ func (o *Options) GetType() (Type, error) {
 	}
 	return SoftKMS, nil
 }
+
+var ErrNonInteractivePasswordPrompt = errors.New("password required in non-interactive context")
+
+var NonInteractivePasswordPrompter = func() PasswordPrompter {
+	return func(s string) ([]byte, error) {
+		return nil, ErrNonInteractivePasswordPrompt
+	}
+}
+
+type PasswordPrompter func(s string) ([]byte, error)

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -5,6 +5,8 @@ import (
 	"crypto"
 	"crypto/x509"
 	"fmt"
+
+	"go.step.sm/crypto/pemutil"
 )
 
 // ProtectionLevel specifies on some KMS how cryptographic operations are
@@ -173,13 +175,14 @@ type CreateKeyResponse struct {
 
 // CreateSignerRequest is the parameter used in the kms.CreateSigner method.
 type CreateSignerRequest struct {
-	Signer        crypto.Signer
-	SigningKey    string
-	SigningKeyPEM []byte
-	TokenLabel    string
-	PublicKey     string
-	PublicKeyPEM  []byte
-	Password      []byte
+	Signer           crypto.Signer
+	SigningKey       string
+	SigningKeyPEM    []byte
+	TokenLabel       string
+	PublicKey        string
+	PublicKeyPEM     []byte
+	Password         []byte
+	PasswordPrompter func() (string, pemutil.PasswordPrompter)
 }
 
 // CreateDecrypterRequest is the parameter used in the kms.Decrypt method.
@@ -188,6 +191,7 @@ type CreateDecrypterRequest struct {
 	DecryptionKey    string
 	DecryptionKeyPEM []byte
 	Password         []byte
+	PasswordPrompter func() (string, pemutil.PasswordPrompter)
 }
 
 // LoadCertificateRequest is the parameter used in the LoadCertificate method of

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -5,8 +5,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"fmt"
-
-	"go.step.sm/crypto/pemutil"
 )
 
 // ProtectionLevel specifies on some KMS how cryptographic operations are
@@ -182,7 +180,7 @@ type CreateSignerRequest struct {
 	PublicKey        string
 	PublicKeyPEM     []byte
 	Password         []byte
-	PasswordPrompter func() (string, pemutil.PasswordPrompter)
+	PasswordPrompter PasswordPrompter
 }
 
 // CreateDecrypterRequest is the parameter used in the kms.Decrypt method.
@@ -191,7 +189,7 @@ type CreateDecrypterRequest struct {
 	DecryptionKey    string
 	DecryptionKeyPEM []byte
 	Password         []byte
-	PasswordPrompter func() (string, pemutil.PasswordPrompter)
+	PasswordPrompter PasswordPrompter
 }
 
 // LoadCertificateRequest is the parameter used in the LoadCertificate method of

--- a/kms/kms.go
+++ b/kms/kms.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.step.sm/crypto/kms/apiv1"
+	"go.step.sm/crypto/pemutil"
 
 	// Enable default implementation
 	"go.step.sm/crypto/kms/softkms"
@@ -34,6 +35,14 @@ type Type = apiv1.Type
 
 // Default is the implementation of the default KMS.
 var Default = &softkms.SoftKMS{}
+
+var ErrNonInteractivePasswordPrompt = errors.New("password required in non-interactive context")
+
+var NonInteractivePasswordPrompter = func() (string, pemutil.PasswordPrompter) {
+	return "non-interactive", func(s string) ([]byte, error) {
+		return nil, ErrNonInteractivePasswordPrompt
+	}
+}
 
 // New initializes a new KMS from the given type.
 func New(ctx context.Context, opts apiv1.Options) (KeyManager, error) {

--- a/kms/kms.go
+++ b/kms/kms.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"go.step.sm/crypto/kms/apiv1"
-	"go.step.sm/crypto/pemutil"
 
 	// Enable default implementation
 	"go.step.sm/crypto/kms/softkms"
@@ -35,14 +34,6 @@ type Type = apiv1.Type
 
 // Default is the implementation of the default KMS.
 var Default = &softkms.SoftKMS{}
-
-var ErrNonInteractivePasswordPrompt = errors.New("password required in non-interactive context")
-
-var NonInteractivePasswordPrompter = func() (string, pemutil.PasswordPrompter) {
-	return "non-interactive", func(s string) ([]byte, error) {
-		return nil, ErrNonInteractivePasswordPrompt
-	}
-}
 
 // New initializes a new KMS from the given type.
 func New(ctx context.Context, opts apiv1.Options) (KeyManager, error) {

--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -74,8 +74,8 @@ func (k *SoftKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
 	}
-	if req.PasswordPrompter != nil {
-		opts = append(opts, pemutil.WithPasswordPrompt(req.PasswordPrompter()))
+	if req.Password == nil && req.PasswordPrompter != nil {
+		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the signing key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 
 	switch {
@@ -158,8 +158,8 @@ func (k *SoftKMS) CreateDecrypter(req *apiv1.CreateDecrypterRequest) (crypto.Dec
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
 	}
-	if req.PasswordPrompter != nil {
-		opts = append(opts, pemutil.WithPasswordPrompt(req.PasswordPrompter()))
+	if req.Password == nil && req.PasswordPrompter != nil {
+		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the decryption key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 
 	switch {

--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -156,7 +156,7 @@ func (k *SoftKMS) CreateDecrypter(req *apiv1.CreateDecrypterRequest) (crypto.Dec
 	var opts []pemutil.Options
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
-	} else if req.Password == nil && req.PasswordPrompter != nil {
+	} else if req.PasswordPrompter != nil {
 		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the decryption key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 

--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -73,8 +73,7 @@ func (k *SoftKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 	var opts []pemutil.Options
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
-	}
-	if req.Password == nil && req.PasswordPrompter != nil {
+	} else if req.Password == nil && req.PasswordPrompter != nil {
 		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the signing key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 
@@ -157,8 +156,7 @@ func (k *SoftKMS) CreateDecrypter(req *apiv1.CreateDecrypterRequest) (crypto.Dec
 	var opts []pemutil.Options
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
-	}
-	if req.Password == nil && req.PasswordPrompter != nil {
+	} else if req.Password == nil && req.PasswordPrompter != nil {
 		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the decryption key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 

--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -73,7 +73,7 @@ func (k *SoftKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 	var opts []pemutil.Options
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
-	} else if req.Password == nil && req.PasswordPrompter != nil {
+	} else if req.PasswordPrompter != nil {
 		opts = append(opts, pemutil.WithPasswordPrompt("Please enter the password to decrypt the signing key", pemutil.PasswordPrompter(req.PasswordPrompter)))
 	}
 

--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -74,6 +74,9 @@ func (k *SoftKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
 	}
+	if req.PasswordPrompter != nil {
+		opts = append(opts, pemutil.WithPasswordPrompt(req.PasswordPrompter()))
+	}
 
 	switch {
 	case req.Signer != nil:
@@ -154,6 +157,9 @@ func (k *SoftKMS) CreateDecrypter(req *apiv1.CreateDecrypterRequest) (crypto.Dec
 	var opts []pemutil.Options
 	if req.Password != nil {
 		opts = append(opts, pemutil.WithPassword(req.Password))
+	}
+	if req.PasswordPrompter != nil {
+		opts = append(opts, pemutil.WithPasswordPrompt(req.PasswordPrompter()))
 	}
 
 	switch {


### PR DESCRIPTION
When configuring SCEP decrypters, primarily when doing so through Remote Administration, it can happen that a password is required for the decrypter key. If the user doesn't provide a value for the password when a password is required, the CA will prompt for the password, but will do so on the CA side as part of the running process; not on the CLI side. It will do so twice, even: first when initializing the provisioner to be able to validate it, then to load it into the actual running process. 

By supporting a `PasswordPrompter` to be set and providing a `NonInteractivePasswordPrompter` that returns an error by default, the password prompt is effectively immediately returned with an error instead of waiting for input on the CA side. This is an example usage:

```golang
decrypter, err := kmsDecrypter.CreateDecrypter(&kmsapi.CreateDecrypterRequest{
	DecryptionKey:    decryptionKey,
	Password:         []byte(s.DecrypterKeyPassword),
	PasswordPrompter: kms.NonInteractivePasswordPrompter,
})		
```

On the CLI, an error similar to the one below will be reported (instead of waiting for the HTTP response):

```console
error initializing provisioner my-scep: failed creating decrypter: password required in non-interactive context
```

It will be reported as an internal error on the CA side with the same message.

If a password is provided by the user, that will be used instead of being prompted. If no password is required, the prompt won't be used, so no error will be returned.

This is a quick and easy way to handle this specific case, specifically for SoftKMS.


Alternatives:
* Check if the user provided the (correct) password on the CLI by trying to read the key before submitting the provisioner to the CA. The key may exist in a KMS that's not accessible from the machine where the CLI is ran, however, so that something else may be wrong if the key can't be read.
* Add support for contexts to the KMS requests, so that we can pass some contextual data (interactive vs. non-interactive usage) with the request and implement logic to handle those cases.


WDYT, @maraino? 