### PR TITLE
Add helpers to return the kms from an uri

### DIFF
--- a/jose/validate.go
+++ b/jose/validate.go
@@ -162,6 +162,12 @@ func validateSigJWK(jwk *JSONWebKey) error {
 			return nil
 		}
 		errctx = "kty 'OKP' and crv 'Ed25519'"
+	case OpaqueSigner:
+		for _, alg := range k.Algs() {
+			if jwk.Algorithm == string(alg) {
+				return nil
+			}
+		}
 	}
 
 	return errors.Errorf("alg '%s' is not compatible with %s", jwk.Algorithm, errctx)

--- a/kms/apiv1/registry.go
+++ b/kms/apiv1/registry.go
@@ -13,12 +13,12 @@ type KeyManagerNewFunc func(ctx context.Context, opts Options) (KeyManager, erro
 
 // Register adds to the registry a method to create a KeyManager of type t.
 func Register(t Type, fn KeyManagerNewFunc) {
-	registry.Store(t, fn)
+	registry.Store(t.normalize(), fn)
 }
 
 // LoadKeyManagerNewFunc returns the function initialize a KayManager.
 func LoadKeyManagerNewFunc(t Type) (KeyManagerNewFunc, bool) {
-	v, ok := registry.Load(t)
+	v, ok := registry.Load(t.normalize())
 	if !ok {
 		return nil, false
 	}

--- a/kms/kms.go
+++ b/kms/kms.go
@@ -32,6 +32,9 @@ type Options = apiv1.Options
 // Type represents the KMS type used.
 type Type = apiv1.Type
 
+// TypeOf returns the KMS type of the given uri.
+var TypeOf = apiv1.TypeOf
+
 // Default is the implementation of the default KMS.
 var Default = &softkms.SoftKMS{}
 


### PR DESCRIPTION
### Description

This commit introduces the helper `kms.TypeOf`, which returns the type of a URI. It also normalizes the type when necessary.

It also adds a commit to be able to validate JWKs that use an OpaqueSigner.
