### PR TITLE
Add signer implementation to TSS2 keys

### DIFF
--- a/tpm/tss2/encode.go
+++ b/tpm/tss2/encode.go
@@ -1,0 +1,62 @@
+package tss2
+
+import (
+	"encoding/pem"
+
+	"github.com/google/go-tpm/legacy/tpm2"
+)
+
+// TPMOption is the type used to modify a [TPMKey].
+type TPMOption func(*TPMKey)
+
+// New creates a new [TPMKey] with the given public and private keys.
+func New(pub, priv []byte, opts ...TPMOption) *TPMKey {
+	key := &TPMKey{
+		Type:       oidLoadableKey,
+		EmptyAuth:  true,
+		Parent:     int(tpm2.HandleOwner),
+		PublicKey:  integrityPrefix(pub),
+		PrivateKey: integrityPrefix(priv),
+	}
+	for _, fn := range opts {
+		fn(key)
+	}
+	return key
+}
+
+// Encode encodes the [TPMKey] returns a [*pem.Block].
+func (k *TPMKey) Encode() (*pem.Block, error) {
+	b, err := MarshalPrivateKey(k)
+	if err != nil {
+		return nil, err
+	}
+	return &pem.Block{
+		Type:  "TSS2 PRIVATE KEY",
+		Bytes: b,
+	}, nil
+}
+
+// EncodeToMemory encodes the [TPMKey]  and returns an encoded PEM block.
+func (k *TPMKey) EncodeToMemory() ([]byte, error) {
+	block, err := k.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(block), nil
+}
+
+// Encode encodes the given public and private key and returns a [*pem.Block].
+func Encode(pub, priv []byte, opts ...TPMOption) (*pem.Block, error) {
+	return New(pub, priv, opts...).Encode()
+}
+
+// EncodeToMemory encodes the given public and private key and returns an
+// encoded PEM block.
+func EncodeToMemory(pub, priv []byte, opts ...TPMOption) ([]byte, error) {
+	return New(pub, priv, opts...).EncodeToMemory()
+}
+
+func integrityPrefix(b []byte) []byte {
+	s := len(b)
+	return append([]byte{byte(s >> 8 & 0xFF), byte(s & 0xFF)}, b...)
+}

--- a/tpm/tss2/encode.go
+++ b/tpm/tss2/encode.go
@@ -1,10 +1,9 @@
 package tss2
 
-import (
-	"encoding/pem"
+import "encoding/pem"
 
-	"github.com/google/go-tpm/legacy/tpm2"
-)
+// handle owner is the reserver handler TPM_RH_OWNER.
+const handleOwner = 0x40000001
 
 // TPMOption is the type used to modify a [TPMKey].
 type TPMOption func(*TPMKey)
@@ -14,9 +13,9 @@ func New(pub, priv []byte, opts ...TPMOption) *TPMKey {
 	key := &TPMKey{
 		Type:       oidLoadableKey,
 		EmptyAuth:  true,
-		Parent:     int(tpm2.HandleOwner),
-		PublicKey:  integrityPrefix(pub),
-		PrivateKey: integrityPrefix(priv),
+		Parent:     handleOwner,
+		PublicKey:  addPrefixLength(pub),
+		PrivateKey: addPrefixLength(priv),
 	}
 	for _, fn := range opts {
 		fn(key)
@@ -56,7 +55,7 @@ func EncodeToMemory(pub, priv []byte, opts ...TPMOption) ([]byte, error) {
 	return New(pub, priv, opts...).EncodeToMemory()
 }
 
-func integrityPrefix(b []byte) []byte {
+func addPrefixLength(b []byte) []byte {
 	s := len(b)
 	return append([]byte{byte(s >> 8 & 0xFF), byte(s & 0xFF)}, b...)
 }

--- a/tpm/tss2/encode.go
+++ b/tpm/tss2/encode.go
@@ -2,7 +2,7 @@ package tss2
 
 import "encoding/pem"
 
-// handle owner is the reserver handler TPM_RH_OWNER.
+// handle owner is the reserved handle TPM_RH_OWNER.
 const handleOwner = 0x40000001
 
 // TPMOption is the type used to modify a [TPMKey].

--- a/tpm/tss2/encode_test.go
+++ b/tpm/tss2/encode_test.go
@@ -1,0 +1,160 @@
+package tss2
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	type args struct {
+		pub  []byte
+		priv []byte
+		opts []TPMOption
+	}
+	tests := []struct {
+		name string
+		args args
+		want *TPMKey
+	}{
+		{"ok", args{[]byte("public"), []byte("private"), nil}, &TPMKey{
+			Type:       oidLoadableKey,
+			EmptyAuth:  true,
+			Parent:     0x40000001,
+			PublicKey:  append([]byte{0, 6}, []byte("public")...),
+			PrivateKey: append([]byte{0, 7}, []byte("private")...),
+		}},
+		{"ok with options", args{[]byte("public"), []byte("private"), []TPMOption{
+			func(k *TPMKey) {
+				k.EmptyAuth = false
+			},
+			func(k *TPMKey) {
+				k.Policy = append(k.Policy, TPMPolicy{CommandCode: 1, CommandPolicy: []byte("command-policy")})
+			},
+		}}, &TPMKey{
+			Type:       oidLoadableKey,
+			EmptyAuth:  false,
+			Policy:     []TPMPolicy{{CommandCode: 1, CommandPolicy: []byte("command-policy")}},
+			Parent:     0x40000001,
+			PublicKey:  append([]byte{0, 6}, []byte("public")...),
+			PrivateKey: append([]byte{0, 7}, []byte("private")...),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, New(tt.args.pub, tt.args.priv, tt.args.opts...))
+		})
+	}
+}
+
+func TestTPMKey_Encode(t *testing.T) {
+	tests := []struct {
+		name      string
+		tpmKey    *TPMKey
+		want      *pem.Block
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", New([]byte("public"), []byte("private")), &pem.Block{
+			Type: "TSS2 PRIVATE KEY",
+			Bytes: []byte{
+				0x30, 0x28,
+				0x6, 0x6, 0x67, 0x81, 0x5, 0xa, 0x1, 0x3,
+				0xa0, 0x3, 0x1, 0x1, 0xff,
+				0x2, 0x4, 0x40, 0x0, 0x0, 0x1,
+				0x4, 0x8, 0x0, 0x6, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63,
+				0x4, 0x9, 0x0, 0x7, 0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65,
+			},
+		}, assert.NoError},
+		{"fail", nil, nil, assert.Error},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.tpmKey.Encode()
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTPMKey_EncodeToMemory(t *testing.T) {
+	tests := []struct {
+		name      string
+		tpmKey    *TPMKey
+		want      []byte
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", New([]byte("public"), []byte("private")), []byte(`-----BEGIN TSS2 PRIVATE KEY-----
+MCgGBmeBBQoBA6ADAQH/AgRAAAABBAgABnB1YmxpYwQJAAdwcml2YXRl
+-----END TSS2 PRIVATE KEY-----
+`), assert.NoError},
+		{"fail", nil, nil, assert.Error},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.tpmKey.EncodeToMemory()
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+			t.Log(string(got))
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	type args struct {
+		pub  []byte
+		priv []byte
+		opts []TPMOption
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      *pem.Block
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", args{[]byte("public"), []byte("private"), nil}, &pem.Block{
+			Type: "TSS2 PRIVATE KEY",
+			Bytes: []byte{
+				0x30, 0x28,
+				0x6, 0x6, 0x67, 0x81, 0x5, 0xa, 0x1, 0x3,
+				0xa0, 0x3, 0x1, 0x1, 0xff,
+				0x2, 0x4, 0x40, 0x0, 0x0, 0x1,
+				0x4, 0x8, 0x0, 0x6, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63,
+				0x4, 0x9, 0x0, 0x7, 0x70, 0x72, 0x69, 0x76, 0x61, 0x74, 0x65,
+			},
+		}, assert.NoError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Encode(tt.args.pub, tt.args.priv, tt.args.opts...)
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEncodeToMemory(t *testing.T) {
+	type args struct {
+		pub  []byte
+		priv []byte
+		opts []TPMOption
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      []byte
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", args{[]byte("public"), []byte("private"), nil}, []byte(`-----BEGIN TSS2 PRIVATE KEY-----
+MCgGBmeBBQoBA6ADAQH/AgRAAAABBAgABnB1YmxpYwQJAAdwcml2YXRl
+-----END TSS2 PRIVATE KEY-----
+`), assert.NoError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EncodeToMemory(tt.args.pub, tt.args.priv, tt.args.opts...)
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tpm/tss2/encode_test.go
+++ b/tpm/tss2/encode_test.go
@@ -95,7 +95,6 @@ MCgGBmeBBQoBA6ADAQH/AgRAAAABBAgABnB1YmxpYwQJAAdwcml2YXRl
 			got, err := tt.tpmKey.EncodeToMemory()
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
-			t.Log(string(got))
 		})
 	}
 }

--- a/tpm/tss2/other_test.go
+++ b/tpm/tss2/other_test.go
@@ -1,0 +1,14 @@
+//go:build !tpm && !tpmsimulator
+
+package tss2
+
+import (
+	"io"
+	"testing"
+)
+
+func openTPM(t *testing.T) io.ReadWriteCloser {
+	t.Helper()
+	t.Skip("Use tags tpm or tpmsimulator")
+	return nil
+}

--- a/tpm/tss2/signer.go
+++ b/tpm/tss2/signer.go
@@ -1,3 +1,19 @@
+// Copyright 2023 Smallstep Labs, Inc
+// Copyright 2023 David Woodhouse, @dwmw2
+// Copyright 2023 @google/go-tpm-admin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tss2
 
 import (

--- a/tpm/tss2/signer.go
+++ b/tpm/tss2/signer.go
@@ -59,6 +59,8 @@ type Signer struct {
 // [TPMKey]. The caller is responsible of opening and closing the TPM.
 func CreateSigner(rw io.ReadWriter, key *TPMKey) (crypto.Signer, error) {
 	switch {
+	case rw == nil:
+		return nil, fmt.Errorf("invalid TPM channel: rw cannot be nil")
 	case !key.Type.Equal(oidLoadableKey):
 		return nil, fmt.Errorf("invalid TSS2 key: type %q is not valid", key.Type.String())
 	case len(key.Policy) != 0:

--- a/tpm/tss2/signer.go
+++ b/tpm/tss2/signer.go
@@ -1,0 +1,191 @@
+package tss2
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+var primaryParams = tpm2.Public{
+	Type:       tpm2.AlgECC,
+	NameAlg:    tpm2.AlgSHA256,
+	Attributes: tpm2.FlagStorageDefault,
+	ECCParameters: &tpm2.ECCParams{
+		Symmetric: &tpm2.SymScheme{
+			Alg:     tpm2.AlgAES,
+			KeyBits: 128,
+			Mode:    tpm2.AlgCFB,
+		},
+		Sign: &tpm2.SigScheme{
+			Alg: tpm2.AlgNull,
+		},
+		CurveID: tpm2.CurveNISTP256,
+	},
+}
+
+// Signer implements [crypto.Signer] using a [TPMKey].
+type Signer struct {
+	rw        io.ReadWriter
+	publicKey crypto.PublicKey
+	tpmKey    *TPMKey
+}
+
+// CreateSigner creates a new [crypto.Signer] with the given TPM (rw) and
+// [TPMKey]. The caller is responsible of opening and closing the TPM.
+func CreateSigner(rw io.ReadWriter, key *TPMKey) (crypto.Signer, error) {
+	switch {
+	case !key.Type.Equal(oidLoadableKey):
+		return nil, fmt.Errorf("invalid TSS2 key: type %q is not valid", key.Type.String())
+	case len(key.Policy) != 0:
+		return nil, errors.New("invalid TSS2 key: policy is not implemented")
+	case len(key.AuthPolicy) != 0:
+		return nil, errors.New("invalid TSS2 key: auth policy is not implemented")
+	case len(key.Secret) > 0:
+		return nil, errors.New("invalid TSS2 key: secret should not be set")
+	case !validateParent(key.Parent):
+		return nil, fmt.Errorf("invalid TSS2 key: parent '%d' is not valid", key.Parent)
+	case !validateKey(key.PublicKey):
+		return nil, errors.New("invalid TSS2 key: public key is invalid")
+	case !validateKey(key.PrivateKey):
+		return nil, errors.New("invalid TSS2 key: private key key is invalid")
+	}
+
+	public, err := tpm2.DecodePublic(key.PublicKey[2:])
+	if err != nil {
+		return nil, fmt.Errorf("error decoding public key: %w", err)
+	}
+	if public.Type != tpm2.AlgRSA && public.Type != tpm2.AlgECC {
+		return nil, fmt.Errorf("invalid TSS2 key: public key type %q is not valid", public.Type.String())
+	}
+	publicKey, err := public.Key()
+	if err != nil {
+		return nil, fmt.Errorf("error creating public key: %w", err)
+	}
+
+	return &Signer{
+		rw:        rw,
+		publicKey: publicKey,
+		tpmKey:    key,
+	}, nil
+}
+
+func (s *Signer) Public() crypto.PublicKey {
+	return s.publicKey
+}
+
+func (s *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	parentHandle := tpmutil.Handle(s.tpmKey.Parent)
+	if !handleIsPersistent(s.tpmKey.Parent) {
+		parentHandle, _, err = tpm2.CreatePrimary(s.rw, parentHandle, tpm2.PCRSelection{}, "", "", primaryParams)
+		if err != nil {
+			return nil, fmt.Errorf("error creating primary: %w", err)
+		}
+		defer tpm2.FlushContext(s.rw, parentHandle)
+	}
+
+	keyHandle, _, err := tpm2.Load(s.rw, parentHandle, "", s.tpmKey.PublicKey[2:], s.tpmKey.PrivateKey[2:])
+	if err != nil {
+		return nil, fmt.Errorf("error loading key handle: %w", err)
+	}
+	defer tpm2.FlushContext(s.rw, keyHandle)
+
+	switch p := s.publicKey.(type) {
+	case *ecdsa.PublicKey:
+		return signECDSA(s.rw, keyHandle, digest, p.Curve)
+	case *rsa.PublicKey:
+		return signRSA(s.rw, keyHandle, digest, opts)
+	default:
+		return nil, fmt.Errorf("unsupported signing key type %T", s.publicKey)
+	}
+}
+
+// https://github.com/smallstep/go-attestation/blob/f5480326fb6d63859537ec89fbea7c62485bc4da/attest/wrapped_tpm20.go#L513
+func signECDSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, curve elliptic.Curve) ([]byte, error) {
+	scheme, err := curveSigScheme(curve)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := tpm2.Sign(rw, key, "", digest, nil, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ECDSA signature: %w", err)
+	}
+	if sig.ECC == nil {
+		return nil, fmt.Errorf("expected ECDSA signature, got: %v", sig.Alg)
+	}
+	return asn1.Marshal(struct {
+		R *big.Int
+		S *big.Int
+	}{sig.ECC.R, sig.ECC.S})
+}
+
+// https://github.com/smallstep/go-attestation/blob/f5480326fb6d63859537ec89fbea7c62485bc4da/attest/wrapped_tpm20.go#L527
+func signRSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	h, err := tpm2.HashToAlgorithm(opts.HashFunc())
+	if err != nil {
+		return nil, fmt.Errorf("incorrect hash algorithm: %v", err)
+	}
+
+	scheme := &tpm2.SigScheme{
+		Alg:  tpm2.AlgRSASSA,
+		Hash: h,
+	}
+
+	if pss, ok := opts.(*rsa.PSSOptions); ok {
+		if pss.SaltLength != rsa.PSSSaltLengthAuto && pss.SaltLength != rsa.PSSSaltLengthEqualsHash && pss.SaltLength != len(digest) {
+			return nil, fmt.Errorf("invalid PSS salt length %d, expected rsa.PSSSaltLengthAuto, rsa.PSSSaltLengthEqualsHash or %d", pss.SaltLength, len(digest))
+		}
+		scheme.Alg = tpm2.AlgRSAPSS
+	}
+
+	sig, err := tpm2.Sign(rw, key, "", digest, nil, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RSA signature: %v", err)
+	}
+	if sig.RSA == nil {
+		return nil, fmt.Errorf("expected RSA signature, got: %v", sig.Alg)
+	}
+	return sig.RSA.Signature, nil
+}
+
+func curveSigScheme(curve elliptic.Curve) (*tpm2.SigScheme, error) {
+	scheme := &tpm2.SigScheme{
+		Alg: tpm2.AlgECDSA,
+	}
+	switch curve {
+	case elliptic.P256():
+		scheme.Hash = tpm2.AlgSHA256
+	case elliptic.P384():
+		scheme.Hash = tpm2.AlgSHA384
+	case elliptic.P521():
+		scheme.Hash = tpm2.AlgSHA512
+	default:
+		return nil, fmt.Errorf("unsupported curve %s", curve.Params().Name)
+	}
+
+	return scheme, nil
+}
+
+func handleIsPersistent(h int) bool {
+	return (h >> 24) == int(tpm2.HandleTypePersistent)
+}
+
+func validateParent(parent int) bool {
+	return handleIsPersistent(parent) ||
+		parent == int(tpm2.HandleOwner) ||
+		parent == int(tpm2.HandleNull) ||
+		parent == int(tpm2.HandleEndorsement) ||
+		parent == int(tpm2.HandlePlatform)
+}
+
+func validateKey(b []byte) bool {
+	return len(b) >= 2 && len(b)-2 == (int(b[0])<<8)+int(b[1])
+}

--- a/tpm/tss2/signer.go
+++ b/tpm/tss2/signer.go
@@ -78,7 +78,7 @@ type Signer struct {
 }
 
 // CreateSigner creates a new [crypto.Signer] with the given TPM (rw) and
-// [TPMKey]. The caller is responsible of opening and closing the TPM.
+// [TPMKey]. The caller is responsible for opening and closing the TPM.
 func CreateSigner(rw io.ReadWriter, key *TPMKey) (*Signer, error) {
 	switch {
 	case rw == nil:
@@ -119,10 +119,10 @@ func CreateSigner(rw io.ReadWriter, key *TPMKey) (*Signer, error) {
 	}, nil
 }
 
-// SetSRKTemplate allows to change the Storage Primary Key (SRK) template used
+// SetSRKTemplate allows to change the Storage Root Key (SRK) template used
 // to load the the public/private blobs into an object in the TPM.
 //
-// It currently defaults to [RSASRKTemplate], the same used ad default in the
+// It currently defaults to [RSASRKTemplate], the same used as the default in the
 // [go.step.sm/crypto/tpm] package.
 //
 // # Experimental

--- a/tpm/tss2/signer_test.go
+++ b/tpm/tss2/signer_test.go
@@ -1,0 +1,199 @@
+package tss2
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/pem"
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var defaultKeyParamsEC = tpm2.Public{
+	Type:       tpm2.AlgECC,
+	NameAlg:    tpm2.AlgSHA256,
+	Attributes: tpm2.FlagSignerDefault ^ tpm2.FlagRestricted,
+	ECCParameters: &tpm2.ECCParams{
+		Sign: &tpm2.SigScheme{
+			Alg:  tpm2.AlgECDSA,
+			Hash: tpm2.AlgSHA256,
+		},
+		CurveID: tpm2.CurveNISTP256,
+	},
+}
+
+var defaultKeyParamsRSA = tpm2.Public{
+	Type:       tpm2.AlgRSA,
+	NameAlg:    tpm2.AlgSHA256,
+	Attributes: tpm2.FlagSignerDefault ^ tpm2.FlagRestricted,
+	RSAParameters: &tpm2.RSAParams{
+		Sign: &tpm2.SigScheme{
+			Alg:  tpm2.AlgRSASSA,
+			Hash: tpm2.AlgSHA256,
+		},
+		KeyBits: 2048,
+	},
+}
+
+var defaultKeyParamsRSAPSS = tpm2.Public{
+	Type:       tpm2.AlgRSA,
+	NameAlg:    tpm2.AlgSHA256,
+	Attributes: tpm2.FlagSignerDefault ^ tpm2.FlagRestricted,
+	RSAParameters: &tpm2.RSAParams{
+		Sign: &tpm2.SigScheme{
+			Alg:  tpm2.AlgRSAPSS,
+			Hash: tpm2.AlgSHA256,
+		},
+		KeyBits: 2048,
+	},
+}
+
+func TestSign(t *testing.T) {
+	rw := openTPM(t)
+	t.Cleanup(func() {
+		assert.NoError(t, rw.Close())
+	})
+
+	keyHnd, _, err := tpm2.CreatePrimary(rw, tpm2.HandleOwner, tpm2.PCRSelection{}, "", "", primaryParams)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tpm2.FlushContext(rw, keyHnd))
+	})
+
+	tests := []struct {
+		name   string
+		params tpm2.Public
+		opts   crypto.SignerOpts
+	}{
+		{"ok ECDSA", defaultKeyParamsEC, crypto.SHA256},
+		{"ok RSA", defaultKeyParamsRSA, crypto.SHA256},
+		{"ok RSAPSS", defaultKeyParamsRSAPSS, &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto, Hash: crypto.SHA256,
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priv, pub, _, _, _, err := tpm2.CreateKey(rw, keyHnd, tpm2.PCRSelection{}, "", "", tt.params)
+			require.NoError(t, err)
+
+			signer, err := CreateSigner(rw, New(pub, priv))
+			require.NoError(t, err)
+
+			hash := crypto.SHA256.New()
+			hash.Write([]byte("rulingly-quailed-cloacal-indifferentist-roughhoused-self-mad"))
+			sum := hash.Sum(nil)
+
+			sig, err := signer.Sign(rand.Reader, sum[:], tt.opts)
+			require.NoError(t, err)
+
+			switch pub := signer.Public().(type) {
+			case *ecdsa.PublicKey:
+				assert.Equal(t, tpm2.AlgECC, tt.params.Type)
+				assert.True(t, ecdsa.VerifyASN1(pub, sum[:], sig))
+			case *rsa.PublicKey:
+				assert.Equal(t, tpm2.AlgRSA, tt.params.Type)
+				switch tt.params.RSAParameters.Sign.Alg {
+				case tpm2.AlgRSASSA:
+					assert.NoError(t, rsa.VerifyPKCS1v15(pub, tt.opts.HashFunc(), sum[:], sig))
+				case tpm2.AlgRSAPSS:
+					assert.NoError(t, rsa.VerifyPSS(pub, crypto.SHA256, sum[:], sig, nil))
+				default:
+					t.Errorf("unexpected RSAParameters.Sign.Alg %v", tt.params.RSAParameters.Sign.Alg)
+				}
+			default:
+				t.Errorf("unexpected PublicKey type %T", pub)
+			}
+		})
+	}
+}
+
+func TestCreateSigner(t *testing.T) {
+	parsePEM := func(s string) []byte {
+		block, _ := pem.Decode([]byte(s))
+		return block.Bytes
+	}
+
+	var rw bytes.Buffer
+	key, err := ParsePrivateKey(parsePEM(p256TSS2PEM))
+	require.NoError(t, err)
+
+	pub, err := tpm2.DecodePublic(key.PublicKey[2:])
+	require.NoError(t, err)
+	publicKey, err := pub.Key()
+	require.NoError(t, err)
+
+	modKey := func(fn TPMOption) *TPMKey {
+		return New(key.PublicKey[2:], key.PrivateKey[2:], fn)
+	}
+
+	type args struct {
+		rw  io.ReadWriter
+		key *TPMKey
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      crypto.Signer
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", args{&rw, key}, &Signer{
+			rw: &rw, publicKey: publicKey, tpmKey: key,
+		}, assert.NoError},
+		{"fail type", args{&rw, modKey(func(k *TPMKey) {
+			k.Type = oidSealedKey
+		})}, nil, assert.Error},
+		{"fail policy", args{&rw, modKey(func(k *TPMKey) {
+			k.Policy = []TPMPolicy{{CommandCode: 1, CommandPolicy: []byte("command-policy")}}
+		})}, nil, assert.Error},
+		{"fail authPolicy", args{&rw, modKey(func(k *TPMKey) {
+			k.AuthPolicy = []TPMAuthPolicy{{Name: "auth", Policy: []TPMPolicy{{CommandCode: 1, CommandPolicy: []byte("command-policy")}}}}
+		})}, nil, assert.Error},
+		{"fail secret", args{&rw, modKey(func(k *TPMKey) {
+			k.Secret = []byte("secret")
+		})}, nil, assert.Error},
+		{"fail parent", args{&rw, modKey(func(k *TPMKey) {
+			k.Parent = 0
+		})}, nil, assert.Error},
+		{"fail publicKey", args{&rw, modKey(func(k *TPMKey) {
+			k.PublicKey = key.PublicKey[2:]
+		})}, nil, assert.Error},
+		{"fail privateKey", args{&rw, modKey(func(k *TPMKey) {
+			k.PrivateKey = key.PrivateKey[2:]
+		})}, nil, assert.Error},
+		{"fail decodePublic", args{&rw, modKey(func(k *TPMKey) {
+			k.PublicKey = append([]byte{0, 6}, []byte("public")...)
+		})}, nil, assert.Error},
+		{"fail type", args{&rw, modKey(func(k *TPMKey) {
+			p := tpm2.Public{
+				Type:       tpm2.AlgSymCipher,
+				NameAlg:    tpm2.AlgAES,
+				Attributes: tpm2.FlagSignerDefault ^ tpm2.FlagRestricted,
+				SymCipherParameters: &tpm2.SymCipherParams{
+					Symmetric: &tpm2.SymScheme{
+						Alg:     tpm2.AlgAES,
+						KeyBits: 128,
+						Mode:    tpm2.AlgCFB,
+					},
+					Unique: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+			}
+			b, err := p.Encode()
+			if assert.NoError(t, err) {
+				k.PublicKey = integrityPrefix(b)
+			}
+		})}, nil, assert.Error},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateSigner(tt.args.rw, tt.args.key)
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tpm/tss2/signer_test.go
+++ b/tpm/tss2/signer_test.go
@@ -145,6 +145,7 @@ func TestCreateSigner(t *testing.T) {
 		{"ok", args{&rw, key}, &Signer{
 			rw: &rw, publicKey: publicKey, tpmKey: key,
 		}, assert.NoError},
+		{"fail rw", args{nil, key}, nil, assert.Error},
 		{"fail type", args{&rw, modKey(func(k *TPMKey) {
 			k.Type = oidSealedKey
 		})}, nil, assert.Error},

--- a/tpm/tss2/signer_test.go
+++ b/tpm/tss2/signer_test.go
@@ -89,20 +89,20 @@ func TestSign(t *testing.T) {
 			hash.Write([]byte("rulingly-quailed-cloacal-indifferentist-roughhoused-self-mad"))
 			sum := hash.Sum(nil)
 
-			sig, err := signer.Sign(rand.Reader, sum[:], tt.opts)
+			sig, err := signer.Sign(rand.Reader, sum, tt.opts)
 			require.NoError(t, err)
 
 			switch pub := signer.Public().(type) {
 			case *ecdsa.PublicKey:
 				assert.Equal(t, tpm2.AlgECC, tt.params.Type)
-				assert.True(t, ecdsa.VerifyASN1(pub, sum[:], sig))
+				assert.True(t, ecdsa.VerifyASN1(pub, sum, sig))
 			case *rsa.PublicKey:
 				assert.Equal(t, tpm2.AlgRSA, tt.params.Type)
 				switch tt.params.RSAParameters.Sign.Alg {
 				case tpm2.AlgRSASSA:
-					assert.NoError(t, rsa.VerifyPKCS1v15(pub, tt.opts.HashFunc(), sum[:], sig))
+					assert.NoError(t, rsa.VerifyPKCS1v15(pub, tt.opts.HashFunc(), sum, sig))
 				case tpm2.AlgRSAPSS:
-					assert.NoError(t, rsa.VerifyPSS(pub, crypto.SHA256, sum[:], sig, nil))
+					assert.NoError(t, rsa.VerifyPSS(pub, crypto.SHA256, sum, sig, nil))
 				default:
 					t.Errorf("unexpected RSAParameters.Sign.Alg %v", tt.params.RSAParameters.Sign.Alg)
 				}

--- a/tpm/tss2/simulator_test.go
+++ b/tpm/tss2/simulator_test.go
@@ -1,0 +1,20 @@
+//go:build tpmsimulator
+
+package tss2
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.step.sm/crypto/tpm/simulator"
+)
+
+func openTPM(t *testing.T) io.ReadWriteCloser {
+	t.Helper()
+
+	sim, err := simulator.New()
+	require.NoError(t, err)
+	require.NoError(t, sim.Open())
+	return sim
+}

--- a/tpm/tss2/tpm_test.go
+++ b/tpm/tss2/tpm_test.go
@@ -1,0 +1,19 @@
+//go:build tpm
+
+package tss2
+
+import (
+	"io"
+	"testing"
+
+	"github.com/google/go-tpm/legacy/tpm2"
+	"github.com/stretchr/testify/require"
+)
+
+func openTPM(t *testing.T) io.ReadWriteCloser {
+	t.Helper()
+
+	rwc, err := tpm2.OpenTPM()
+	require.NoError(t, err)
+	return rwc
+}


### PR DESCRIPTION
### Description

This PR adds a signer implementation for TSS2 keys, it also adds new methods to marshal those keys to PEM.
