### PR TITLE
Add a configurable retention period for cloudkms keys

### DIFF
--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -162,11 +162,11 @@ type CreateKeyRequest struct {
 	// Used by: yubikey
 	TouchPolicy TouchPolicy
 
-	// RetentionPeriod is the period of time that a key spends in a destroy
-	// scheduled state before transitioning to destroyed.
+	// DestroyRetentionPeriod is the period of time that a key spends in a
+	// destroy scheduled state before transitioning to destroyed.
 	//
 	// Used by: cloudkms
-	RetentionPeriod time.Duration
+	DestroyRetentionPeriod time.Duration
 }
 
 // CreateKeyResponse is the response value of the kms.CreateKey method.

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"fmt"
+	"time"
 )
 
 // ProtectionLevel specifies on some KMS how cryptographic operations are
@@ -160,6 +161,12 @@ type CreateKeyRequest struct {
 	//
 	// Used by: yubikey
 	TouchPolicy TouchPolicy
+
+	// RetentionPeriod is the period of time that a key spends in a destroy
+	// scheduled state before transitioning to destroyed.
+	//
+	// Used by: cloudkms
+	RetentionPeriod time.Duration
 }
 
 // CreateKeyResponse is the response value of the kms.CreateKey method.

--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -190,8 +190,8 @@ func (k *CloudKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespo
 	}
 
 	var destroyScheduledDuration *durationpb.Duration
-	if req.RetentionPeriod > 0 {
-		destroyScheduledDuration = durationpb.New(req.RetentionPeriod)
+	if req.DestroyRetentionPeriod > 0 {
+		destroyScheduledDuration = durationpb.New(req.DestroyRetentionPeriod)
 	}
 
 	// resource is the plain Google Cloud KMS resource name

--- a/kms/cloudkms/cloudkms_test.go
+++ b/kms/cloudkms/cloudkms_test.go
@@ -288,7 +288,7 @@ func TestCloudKMS_CreateKey(t *testing.T) {
 					return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
 				},
 			}},
-			args{&apiv1.CreateKeyRequest{Name: keyURI, ProtectionLevel: apiv1.HSM, SignatureAlgorithm: apiv1.ECDSAWithSHA256, RetentionPeriod: 24 * time.Hour}},
+			args{&apiv1.CreateKeyRequest{Name: keyURI, ProtectionLevel: apiv1.HSM, SignatureAlgorithm: apiv1.ECDSAWithSHA256, DestroyRetentionPeriod: 24 * time.Hour}},
 			&apiv1.CreateKeyResponse{Name: "cloudkms:" + keyName + "/cryptoKeyVersions/1", PublicKey: pk, CreateSignerRequest: apiv1.CreateSignerRequest{SigningKey: "cloudkms:" + keyName + "/cryptoKeyVersions/1"}}, false},
 		{"ok new key ring", fields{
 			&MockClient{


### PR DESCRIPTION
This commit adds a new option DestroyRetentionPeriod to the kms.CreateKey method to define the period which a deleted key is recovarable. Currently this is only implemented by cloudkms.

Fixes #363