### PR TITLE
Update attestation for a key

### DIFF
--- a/tpm/key_test.go
+++ b/tpm/key_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestKey_MarshalJSON(t *testing.T) {
-
 	ca, err := minica.New(
 		minica.WithGetSignerFunc(
 			func() (crypto.Signer, error) {

--- a/tpm/storage/types.go
+++ b/tpm/storage/types.go
@@ -68,11 +68,13 @@ func (ak *AK) UnmarshalJSON(data []byte) error {
 
 // Key is the type used to store Keys.
 type Key struct {
-	Name       string
-	Data       []byte
-	AttestedBy string
-	Chain      []*x509.Certificate
-	CreatedAt  time.Time
+	Name                 string
+	Data                 []byte
+	AttestedBy           string
+	Chain                []*x509.Certificate
+	CreatedAt            time.Time
+	LatestAttestation    []byte
+	LatestAttestationSig []byte
 }
 
 // MarshalJSON marshals the Key into JSON.
@@ -83,11 +85,13 @@ func (key *Key) MarshalJSON() ([]byte, error) {
 	}
 
 	sk := serializedKey{
-		Name:       key.Name,
-		Type:       typeKey,
-		Data:       key.Data,
-		AttestedBy: key.AttestedBy,
-		CreatedAt:  key.CreatedAt,
+		Name:                 key.Name,
+		Type:                 typeKey,
+		Data:                 key.Data,
+		AttestedBy:           key.AttestedBy,
+		CreatedAt:            key.CreatedAt,
+		LatestAttestation:    key.LatestAttestation,
+		LatestAttestationSig: key.LatestAttestationSig,
 	}
 
 	if len(chain) > 0 {
@@ -112,6 +116,8 @@ func (key *Key) UnmarshalJSON(data []byte) error {
 	key.Data = sk.Data
 	key.AttestedBy = sk.AttestedBy
 	key.CreatedAt = sk.CreatedAt
+	key.LatestAttestation = sk.LatestAttestation
+	key.LatestAttestationSig = sk.LatestAttestationSig
 
 	if len(sk.Chain) > 0 {
 		chain := make([]*x509.Certificate, len(sk.Chain))
@@ -153,12 +159,14 @@ type serializedAK struct {
 // serializedKey is the struct used when marshaling
 // a storage Key to JSON.
 type serializedKey struct {
-	Name       string        `json:"name"`
-	Type       tpmObjectType `json:"type"`
-	Data       []byte        `json:"data"`
-	AttestedBy string        `json:"attestedBy"`
-	Chain      [][]byte      `json:"chain"`
-	CreatedAt  time.Time     `json:"createdAt"`
+	Name                 string        `json:"name"`
+	Type                 tpmObjectType `json:"type"`
+	Data                 []byte        `json:"data"`
+	AttestedBy           string        `json:"attestedBy"`
+	Chain                [][]byte      `json:"chain"`
+	CreatedAt            time.Time     `json:"createdAt"`
+	LatestAttestation    []byte        `json:"latestAttestation"`
+	LatestAttestationSig []byte        `json:"latestAttestationSig"`
 }
 
 // keyForAK returns the key to use when storing an AK.


### PR DESCRIPTION
Currently a new key has to be created every time a new certificate is authorized with the acme device attestation protocol. This allows a new attestation to be generated with fresh qualifying data from the CA.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?
Linux

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Windows

#### Supporting links/other PRs/issues:

💔Thank you!
