### PR TITLE
Do not enforce pin on pkcs11 kms

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -107,7 +107,7 @@ func New(_ context.Context, opts apiv1.Options) (*PKCS11, error) {
 	}
 
 	// We will allow empty pins as some modules might not have a pin by default.
-	// This is the case of softokn used to read NSS databases.
+	// This is the case for softtoken, which is used to read NSS databases.
 	config.Pin = u.Pin()
 	if config.Pin == "" && opts.Pin != "" {
 		config.Pin = opts.Pin

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -106,6 +106,8 @@ func New(_ context.Context, opts apiv1.Options) (*PKCS11, error) {
 		config.Path = defaultModule
 	}
 
+	// We will allow empty pins as some modules might not have a pin by default.
+	// This is the case of softokn used to read NSS databases.
 	config.Pin = u.Pin()
 	if config.Pin == "" && opts.Pin != "" {
 		config.Pin = opts.Pin
@@ -114,8 +116,6 @@ func New(_ context.Context, opts apiv1.Options) (*PKCS11, error) {
 	switch {
 	case config.TokenLabel == "" && config.TokenSerial == "" && config.SlotNumber == nil:
 		return nil, errors.New("kms uri 'token', 'serial' or 'slot-id' are required")
-	case config.Pin == "":
-		return nil, errors.New("kms 'pin' cannot be empty")
 	case config.TokenLabel != "" && config.TokenSerial != "":
 		return nil, errors.New("kms uri 'token' and 'serial' are mutually exclusive")
 	case config.TokenLabel != "" && config.SlotNumber != nil:

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -69,6 +69,10 @@ func TestNew(t *testing.T) {
 			URI:  "pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=pkcs11-test",
 			Pin:  "passowrd",
 		}}, k, false},
+		{"ok no pin", args{context.Background(), apiv1.Options{
+			Type: "pkcs11",
+			URI:  "pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=pkcs11-test",
+		}}, k, false},
 		{"ok with missing module", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
 			URI:  "pkcs11:token=pkcs11-test",
@@ -76,10 +80,6 @@ func TestNew(t *testing.T) {
 		}}, k, false},
 		{"fail missing uri", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",
-		}}, nil, true},
-		{"fail missing pin", args{context.Background(), apiv1.Options{
-			Type: "pkcs11",
-			URI:  "pkcs11:module-path=/usr/local/lib/softhsm/libsofthsm2.so;token=pkcs11-test",
 		}}, nil, true},
 		{"fail missing token/serial/slot-id", args{context.Background(), apiv1.Options{
 			Type: "pkcs11",


### PR DESCRIPTION
This commit removes the enforcement of a pin when a pkcs11 kms is initialized. Some soft pkcs11 implementations, like NSS's soft token, have an empty pin by default.