### PR TITLE
Do not overflow default handle on 32 bits architectures

### DIFF
--- a/tpm/internal/key/key.go
+++ b/tpm/internal/key/key.go
@@ -32,8 +32,8 @@ const (
 	nvramEkNonceIndex = 0x1c00003
 
 	// Defined in "Registry of reserved TPM 2.0 handles and localities", and checked on a glinux machine.
-	commonSrkEquivalentHandle = 0x81000001
-	commonEkEquivalentHandle  = 0x81010001
+	commonSrkEquivalentHandle = tpmutil.Handle(0x81000001)
+	commonEkEquivalentHandle  = tpmutil.Handle(0x81010001)
 )
 
 // Key encodings

--- a/tpm/tss2.go
+++ b/tpm/tss2.go
@@ -3,6 +3,8 @@ package tpm
 import (
 	"context"
 
+	"github.com/google/go-tpm/tpmutil"
+
 	"go.step.sm/crypto/tpm/tss2"
 )
 
@@ -11,7 +13,7 @@ const (
 	// and checked on a glinux machine. This is the default parent handle
 	// used by go-tpm and go-attestation, and thus also the default handle
 	// set when marshaling to the TSS2 format.
-	commonSrkEquivalentHandle = 0x81000001
+	commonSrkEquivalentHandle = tpmutil.Handle(0x81000001)
 )
 
 // ToTSS2 gets the public and private blobs and returns a [*tss2.TPMKey].

--- a/tpm/tss2/encode.go
+++ b/tpm/tss2/encode.go
@@ -2,18 +2,20 @@ package tss2
 
 import (
 	"encoding/pem"
+
+	"github.com/google/go-tpm/tpmutil"
 )
 
 // handleOwner is the reserved handle TPM_RH_OWNER.
-const handleOwner = 0x40000001
+const handleOwner = tpmutil.Handle(0x40000001)
 
 // TPMOption is the type used to modify a [TPMKey].
 type TPMOption func(*TPMKey)
 
 // WithParent sets the [TPMKey] parent handle.
-func WithParent(parent int) TPMOption {
+func WithParent(parent tpmutil.Handle) TPMOption {
 	return func(t *TPMKey) {
-		t.Parent = parent
+		t.Parent = int(parent)
 	}
 }
 
@@ -22,7 +24,7 @@ func New(pub, priv []byte, opts ...TPMOption) *TPMKey {
 	key := &TPMKey{
 		Type:       oidLoadableKey,
 		EmptyAuth:  true,
-		Parent:     handleOwner,
+		Parent:     int(handleOwner),
 		PublicKey:  addPrefixLength(pub),
 		PrivateKey: addPrefixLength(priv),
 	}


### PR DESCRIPTION
The default handle 0x81000001 (2164260865) overflows int if compiled on a 32 bits architecture (linux/386). This change changes the type of the handles to tpmutil.Handle that are uint32.
