### PR TITLE
Add SigningKey to softkms CreateKey response

### DIFF
--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -122,12 +122,14 @@ func (k *SoftKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespon
 		return nil, errors.Errorf("softKMS createKey result is not a crypto.Signer: type %T", priv)
 	}
 
+	name := filename(req.Name)
 	return &apiv1.CreateKeyResponse{
-		Name:       filename(req.Name),
+		Name:       name,
 		PublicKey:  pub,
 		PrivateKey: priv,
 		CreateSignerRequest: apiv1.CreateSignerRequest{
-			Signer: signer,
+			Signer:     signer,
+			SigningKey: name,
 		},
 	}, nil
 }

--- a/kms/softkms/softkms_test.go
+++ b/kms/softkms/softkms_test.go
@@ -182,28 +182,28 @@ func TestSoftKMS_CreateKey(t *testing.T) {
 	}{
 		{"p256", args{&apiv1.CreateKeyRequest{Name: "p256", SignatureAlgorithm: apiv1.ECDSAWithSHA256}}, func() (interface{}, interface{}, error) {
 			return p256.Public(), p256, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "p256", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256}}, params{"EC", "P-256", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "p256", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256, SigningKey: "p256"}}, params{"EC", "P-256", 0}, false},
 		{"rsa", args{&apiv1.CreateKeyRequest{Name: "rsa3072", SignatureAlgorithm: apiv1.SHA256WithRSA}}, func() (interface{}, interface{}, error) {
 			return rsa2048.Public(), rsa2048, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "rsa3072", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048}}, params{"RSA", "", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "rsa3072", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048, SigningKey: "rsa3072"}}, params{"RSA", "", 0}, false},
 		{"rsa2048", args{&apiv1.CreateKeyRequest{Name: "rsa2048", SignatureAlgorithm: apiv1.SHA256WithRSA, Bits: 2048}}, func() (interface{}, interface{}, error) {
 			return rsa2048.Public(), rsa2048, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "rsa2048", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048}}, params{"RSA", "", 2048}, false},
+		}, &apiv1.CreateKeyResponse{Name: "rsa2048", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048, SigningKey: "rsa2048"}}, params{"RSA", "", 2048}, false},
 		{"rsaPSS2048", args{&apiv1.CreateKeyRequest{Name: "rsa2048", SignatureAlgorithm: apiv1.SHA256WithRSAPSS, Bits: 2048}}, func() (interface{}, interface{}, error) {
 			return rsa2048.Public(), rsa2048, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "rsa2048", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048}}, params{"RSA", "", 2048}, false},
+		}, &apiv1.CreateKeyResponse{Name: "rsa2048", PublicKey: rsa2048.Public(), PrivateKey: rsa2048, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: rsa2048, SigningKey: "rsa2048"}}, params{"RSA", "", 2048}, false},
 		{"ed25519", args{&apiv1.CreateKeyRequest{Name: "ed25519", SignatureAlgorithm: apiv1.PureEd25519}}, func() (interface{}, interface{}, error) {
 			return edpub, edpriv, nil
-		}, &apiv1.CreateKeyResponse{Name: "ed25519", PublicKey: edpub, PrivateKey: edpriv, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: edpriv}}, params{"OKP", "Ed25519", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "ed25519", PublicKey: edpub, PrivateKey: edpriv, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: edpriv, SigningKey: "ed25519"}}, params{"OKP", "Ed25519", 0}, false},
 		{"default", args{&apiv1.CreateKeyRequest{Name: "default"}}, func() (interface{}, interface{}, error) {
 			return p256.Public(), p256, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256}}, params{"EC", "P-256", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256, SigningKey: "default"}}, params{"EC", "P-256", 0}, false},
 		{"uri", args{&apiv1.CreateKeyRequest{Name: "softkms:default"}}, func() (interface{}, interface{}, error) {
 			return p256.Public(), p256, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256}}, params{"EC", "P-256", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256, SigningKey: "default"}}, params{"EC", "P-256", 0}, false},
 		{"path uri", args{&apiv1.CreateKeyRequest{Name: "softkms:path=default"}}, func() (interface{}, interface{}, error) {
 			return p256.Public(), p256, nil //nolint:gocritic // ignore eval order warning
-		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256}}, params{"EC", "P-256", 0}, false},
+		}, &apiv1.CreateKeyResponse{Name: "default", PublicKey: p256.Public(), PrivateKey: p256, CreateSignerRequest: apiv1.CreateSignerRequest{Signer: p256, SigningKey: "default"}}, params{"EC", "P-256", 0}, false},
 		{"fail algorithm", args{&apiv1.CreateKeyRequest{Name: "fail", SignatureAlgorithm: apiv1.SignatureAlgorithm(100)}}, func() (interface{}, interface{}, error) {
 			return p256.Public(), p256, nil //nolint:gocritic // ignore eval order warning
 		}, nil, params{}, true},


### PR DESCRIPTION
This commit adds SigningKey to the softkms CreateKey response. This field is not used by CreateSigner as Signer is present, but the rest of the key managers return the SigningKey.
