### PR TITLE
Add URI support for CloudKMS decrypter

### DIFF
--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -159,7 +159,7 @@ func (k *CloudKMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, 
 	if req.SigningKey == "" {
 		return nil, errors.New("signing key cannot be empty")
 	}
-	return NewSigner(k.client, resourceName(req.SigningKey))
+	return NewSigner(k.client, req.SigningKey)
 }
 
 // CreateKey creates in Google's Cloud KMS a new asymmetric key for signing.

--- a/kms/cloudkms/decrypter.go
+++ b/kms/cloudkms/decrypter.go
@@ -37,7 +37,7 @@ func NewDecrypter(client KeyManagementClient, decryptionKey string) (*Decrypter,
 	// Make sure that the key exists.
 	decrypter := &Decrypter{
 		client:        client,
-		decryptionKey: decryptionKey,
+		decryptionKey: resourceName(decryptionKey),
 	}
 	if err := decrypter.preloadKey(decryptionKey); err != nil { // TODO(hs): (option for) lazy load instead?
 		return nil, err

--- a/kms/cloudkms/decrypter_test.go
+++ b/kms/cloudkms/decrypter_test.go
@@ -43,6 +43,16 @@ func TestCloudKMS_CreateDecrypter(t *testing.T) {
 				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
 			},
 		}}, args{&apiv1.CreateDecrypterRequest{DecryptionKey: keyName}}, &Decrypter{client: &MockClient{}, decryptionKey: keyName, publicKey: pk}, false},
+		{"ok with uri", fields{&MockClient{
+			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
+			},
+		}}, args{&apiv1.CreateDecrypterRequest{DecryptionKey: "cloudkms:resource=" + keyName}}, &Decrypter{client: &MockClient{}, decryptionKey: keyName, publicKey: pk}, false},
+		{"ok with opaque uri", fields{&MockClient{
+			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
+			},
+		}}, args{&apiv1.CreateDecrypterRequest{DecryptionKey: "cloudkms:" + keyName}}, &Decrypter{client: &MockClient{}, decryptionKey: keyName, publicKey: pk}, false},
 		{"fail", fields{&MockClient{
 			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
 				return nil, fmt.Errorf("test error")

--- a/kms/cloudkms/signer.go
+++ b/kms/cloudkms/signer.go
@@ -26,7 +26,7 @@ func NewSigner(c KeyManagementClient, signingKey string) (*Signer, error) {
 	// Make sure that the key exists.
 	signer := &Signer{
 		client:     c,
-		signingKey: signingKey,
+		signingKey: resourceName(signingKey),
 	}
 	if err := signer.preloadKey(signingKey); err != nil {
 		return nil, err

--- a/kms/cloudkms/signer_test.go
+++ b/kms/cloudkms/signer_test.go
@@ -41,6 +41,16 @@ func Test_newSigner(t *testing.T) {
 				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
 			},
 		}, "signingKey"}, &Signer{client: &MockClient{}, signingKey: "signingKey", publicKey: pk}, false},
+		{"ok with uri", args{&MockClient{
+			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
+			},
+		}, "cloudkms:resource=signingKey"}, &Signer{client: &MockClient{}, signingKey: "signingKey", publicKey: pk}, false},
+		{"ok with opaque uri", args{&MockClient{
+			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+				return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
+			},
+		}, "cloudkms:signingKey"}, &Signer{client: &MockClient{}, signingKey: "signingKey", publicKey: pk}, false},
 		{"fail get public key", args{&MockClient{
 			getPublicKey: func(_ context.Context, _ *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
 				return nil, fmt.Errorf("an error")


### PR DESCRIPTION
### Description

This commit adds URI support for the CloudKMS decrypter and the NewSigner method.

Before this change, CreateDecrypter required the raw resource name, while the rest of the methods allow either a raw resource or a URI like `cloudkms:name` or `cloudkms:resource=name`. 