### PR TITLE
Fix GCP CloudKMS resource URIs sometimes starting with `cloudkms:`

### DIFF
--- a/kms/cloudkms/cloudkms.go
+++ b/kms/cloudkms/cloudkms.go
@@ -204,7 +204,7 @@ func (k *CloudKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespo
 		return nil, err
 	}
 
-	var crytoKeyName string
+	var cryptoKeyName string
 
 	ctx, cancel := defaultContext()
 	defer cancel()
@@ -240,13 +240,13 @@ func (k *CloudKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespo
 		if err != nil {
 			return nil, errors.Wrap(err, "cloudKMS CreateCryptoKeyVersion failed")
 		}
-		crytoKeyName = response.Name
+		cryptoKeyName = response.Name
 	} else {
-		crytoKeyName = response.Name + "/cryptoKeyVersions/1"
+		cryptoKeyName = response.Name + "/cryptoKeyVersions/1"
 	}
 
 	// Use uri format for the keys
-	crytoKeyName = uri.NewOpaque(Scheme, crytoKeyName).String()
+	cryptoKeyName = uri.NewOpaque(Scheme, cryptoKeyName).String()
 
 	// Sleep deterministically to avoid retries because of PENDING_GENERATING.
 	// One second is often enough.
@@ -256,17 +256,17 @@ func (k *CloudKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespo
 
 	// Retrieve public key to add it to the response.
 	pk, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
-		Name: crytoKeyName,
+		Name: cryptoKeyName,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cloudKMS GetPublicKey failed")
 	}
 
 	return &apiv1.CreateKeyResponse{
-		Name:      crytoKeyName,
+		Name:      cryptoKeyName,
 		PublicKey: pk,
 		CreateSignerRequest: apiv1.CreateSignerRequest{
-			SigningKey: crytoKeyName,
+			SigningKey: cryptoKeyName,
 		},
 	}, nil
 }

--- a/kms/cloudkms/decrypter.go
+++ b/kms/cloudkms/decrypter.go
@@ -39,19 +39,19 @@ func NewDecrypter(client KeyManagementClient, decryptionKey string) (*Decrypter,
 		client:        client,
 		decryptionKey: resourceName(decryptionKey),
 	}
-	if err := decrypter.preloadKey(decryptionKey); err != nil { // TODO(hs): (option for) lazy load instead?
+	if err := decrypter.preloadKey(); err != nil { // TODO(hs): (option for) lazy load instead?
 		return nil, err
 	}
 
 	return decrypter, nil
 }
 
-func (d *Decrypter) preloadKey(signingKey string) error {
+func (d *Decrypter) preloadKey() error {
 	ctx, cancel := defaultContext()
 	defer cancel()
 
 	response, err := d.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
-		Name: signingKey,
+		Name: d.decryptionKey,
 	})
 	if err != nil {
 		return fmt.Errorf("cloudKMS GetPublicKey failed: %w", err)

--- a/kms/cloudkms/signer.go
+++ b/kms/cloudkms/signer.go
@@ -28,19 +28,19 @@ func NewSigner(c KeyManagementClient, signingKey string) (*Signer, error) {
 		client:     c,
 		signingKey: resourceName(signingKey),
 	}
-	if err := signer.preloadKey(signingKey); err != nil {
+	if err := signer.preloadKey(); err != nil {
 		return nil, err
 	}
 
 	return signer, nil
 }
 
-func (s *Signer) preloadKey(signingKey string) error {
+func (s *Signer) preloadKey() error {
 	ctx, cancel := defaultContext()
 	defer cancel()
 
 	response, err := s.client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
-		Name: signingKey,
+		Name: s.signingKey,
 	})
 	if err != nil {
 		return errors.Wrap(err, "cloudKMS GetPublicKey failed")


### PR DESCRIPTION
An error similar to the one below occurred:

`Resource name 'cloudkms:projects/staging-a23d/locations/global/keyRings/b84b7b21-0993-43fd-b0c4-3c8cd204e635/cryptoKeys/root-key/cryptoKeyVersions/1' does not match pattern 'projects/([^/]{1,100})/locations/([a-zA-Z0-9_-]{1,63})/keyRings/([a-zA-Z0-9_-]{1,63})/cryptoKeys/([a-zA-Z0-9_-]{1,63})/cryptoKeyVersions/([a-zA-Z0-9_-]{1,63})'."`

Not all cases that interact with the actual GCP API used the right format for the key URI. The code was changed to use a GCP resource name while (pre)loading resources from GCP. The case was not caught in unit tests yet, because those rely primarily on mocks and there were no assertions in the mocks. Added some really basic and primitive ones as a means of guard rails. They won't catch everything now, but should catch regressions.
