### PR TITLE
Require ClientAuth when verifying an X5cInsecure certificate

### DIFF
--- a/jose/parse.go
+++ b/jose/parse.go
@@ -267,6 +267,9 @@ func ParseX5cInsecure(tok string, roots []*x509.Certificate) (*JSONWebToken, [][
 		Intermediates: interPool,
 		// A hack so we skip validity period validation.
 		CurrentTime: leaf.NotAfter.Add(-1 * time.Minute),
+		KeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
 	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error verifying x5cInsecure certificate chain")


### PR DESCRIPTION
The X5cInsecure certificate is used by step-ca to renew certificates without using mTLS, usually expired certificates. `Certificate.Verify` defaults to require ServerAuth if no KeyUsages is set as an option. Due to how these tokens are used, it makes more sense to require only ClientAuth.

Note that a few lines after this check is also made:
```go
if leaf.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
	return nil, nil, errors.New("certificate used to sign x5cInsecure token cannot be used for digital signature")
}
```

Related to smallstep/certificates#1843
