### PR TITLE
Add support for a platform kms

### DIFF
--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -219,8 +219,8 @@ func generateECKey(crv string) (crypto.Signer, error) {
 }
 
 func generateRSAKey(bits int) (crypto.Signer, error) {
-	if min := MinRSAKeyBytes * 8; !insecureMode.isSet() && bits < min {
-		return nil, errors.Errorf("the size of the RSA key should be at least %d bits", min)
+	if minBits := MinRSAKeyBytes * 8; !insecureMode.isSet() && bits < minBits {
+		return nil, errors.Errorf("the size of the RSA key should be at least %d bits", minBits)
 	}
 
 	key, err := rsa.GenerateKey(rand.Reader, bits)

--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -139,6 +139,10 @@ const (
 	TPMKMS Type = "tpmkms"
 	// MacKMS is the KMS implementation using macOS Keychain and Secure Enclave.
 	MacKMS Type = "mackms"
+	// PlatformKMS is a KMS implementation that uses other KMS implementations
+	// depending on the OS. It will use mackms on macOS, and tpmkms on linux and
+	// windows.
+	PlatformKMS Type = "kms"
 )
 
 // TypeOf returns the type of of the given uri.
@@ -169,7 +173,7 @@ func (t Type) Validate() error {
 		return nil
 	case YubiKey, PKCS11, TPMKMS: // Hardware based kms.
 		return nil
-	case SSHAgentKMS, CAPIKMS, MacKMS: // Others
+	case SSHAgentKMS, CAPIKMS, MacKMS, PlatformKMS: // Others
 		return nil
 	}
 

--- a/kms/platform/platform.go
+++ b/kms/platform/platform.go
@@ -1,0 +1,177 @@
+package platform
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+// Scheme is the scheme used in uris, the string "kms".
+const Scheme = string(apiv1.PlatformKMS)
+
+func init() {
+	apiv1.Register(apiv1.PlatformKMS, func(ctx context.Context, opts apiv1.Options) (apiv1.KeyManager, error) {
+		return New(ctx, opts)
+	})
+}
+
+type KMS struct {
+	backend       platformKeyManager
+	defaultSigAlg apiv1.SignatureAlgorithm
+	defaultBits   int
+}
+
+type platformKeyManager interface {
+	apiv1.KeyManager
+	apiv1.CertificateChainManager
+	DeleteKey(req *apiv1.DeleteKeyRequest) error
+	DeleteCertificate(req *apiv1.DeleteCertificateRequest) error
+}
+
+// New returns a new PlatformKMS. This kms will use mackms on macOS, and tpmkms
+// for linux and windows.
+func New(ctx context.Context, o apiv1.Options) (*KMS, error) {
+	return newKMS(ctx, o)
+}
+
+func (k *KMS) GetPublicKey(req *apiv1.GetPublicKeyRequest) (crypto.PublicKey, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("getPublicKeyRequest 'name' cannot be empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return k.backend.GetPublicKey(&apiv1.GetPublicKeyRequest{
+		Name: name,
+	})
+}
+
+func (k *KMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyResponse, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("createKeyRequest 'name' cannot empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	// With mackms we can create multiple keys with the same name but tpmkms
+	// cannot. Checking the presence of the key makes sure that we don't create
+	// a new key with the same name.
+	if _, err := k.backend.GetPublicKey(&apiv1.GetPublicKeyRequest{
+		Name: name,
+	}); err == nil {
+		return nil, apiv1.AlreadyExistsError{}
+	}
+
+	return k.backend.CreateKey(&apiv1.CreateKeyRequest{
+		Name:               name,
+		SignatureAlgorithm: cmpOr(req.SignatureAlgorithm, k.defaultSigAlg),
+		Bits:               cmpOr(req.Bits, k.defaultBits),
+	})
+}
+
+func (k *KMS) DeleteKey(req *apiv1.DeleteKeyRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("deleteKeyRequest 'name' cannot be empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return err
+	}
+	return k.backend.DeleteKey(&apiv1.DeleteKeyRequest{
+		Name: name,
+	})
+}
+
+func (k *KMS) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, error) {
+	if req.SigningKey == "" {
+		return nil, fmt.Errorf("createSignerRequest 'signingKey' cannot be empty")
+	}
+	signingKey, err := k.createURI(req.SigningKey)
+	if err != nil {
+		return nil, err
+	}
+	return k.backend.CreateSigner(&apiv1.CreateSignerRequest{
+		SigningKey: signingKey,
+	})
+}
+
+func (k *KMS) CreateAttestation(*apiv1.CreateAttestationRequest) (*apiv1.CreateAttestationResponse, error) {
+	return nil, apiv1.NotImplementedError{}
+}
+
+func (k *KMS) LoadCertificateChain(req *apiv1.LoadCertificateChainRequest) ([]*x509.Certificate, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("loadCertificateChainRequest 'name' cannot be empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return k.backend.LoadCertificateChain(&apiv1.LoadCertificateChainRequest{
+		Name: name,
+	})
+}
+
+func (k *KMS) StoreCertificateChain(req *apiv1.StoreCertificateChainRequest) error {
+	switch {
+	case req.Name == "":
+		return errors.New("storeCertificateChainRequest 'name' cannot be empty")
+	case len(req.CertificateChain) == 0:
+		return errors.New("storeCertificateChainRequest 'certificateChain' cannot be empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return err
+	}
+	return k.backend.StoreCertificateChain(&apiv1.StoreCertificateChainRequest{
+		Name:             name,
+		CertificateChain: req.CertificateChain,
+	})
+}
+
+func (k *KMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("deleteCertificateRequest 'name' cannot be empty")
+	}
+	name, err := k.createURI(req.Name)
+	if err != nil {
+		return err
+	}
+	return k.backend.DeleteCertificate(&apiv1.DeleteCertificateRequest{
+		Name: name,
+	})
+}
+
+func (k *KMS) Close() error {
+	return k.backend.Close()
+}
+
+// creates a kms specific uri. Supported parameters are:
+//   - "name": string value representing a key, certificate, ... (required)
+//   - "ak": boolean value representing in the key is an attestation key.
+//   - "attest-by": string value representing the attestation key name.
+//   - "qualifying-data": the data to be attested.
+func (k *KMS) createURI(rawuri string) (string, error) {
+	return createURI(rawuri)
+}
+
+// cmpOr returns the first of its arguments that is not equal to the zero value.
+// If no argument is non-zero, it returns the zero value.
+//
+// This method is the same as cmp.Or, but that one was added on go1.22.0
+func cmpOr[T comparable](vals ...T) T {
+	var zero T
+	for _, val := range vals {
+		if val != zero {
+			return val
+		}
+	}
+	return zero
+}

--- a/kms/platform/platform_darwin.go
+++ b/kms/platform/platform_darwin.go
@@ -1,0 +1,41 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"go.step.sm/crypto/kms/apiv1"
+	"go.step.sm/crypto/kms/mackms"
+	"go.step.sm/crypto/kms/uri"
+)
+
+func newKMS(ctx context.Context, _ apiv1.Options) (*KMS, error) {
+	k, err := mackms.New(ctx, apiv1.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("error initializing mackms: %w", err)
+	}
+	return &KMS{
+		backend:       k,
+		defaultSigAlg: apiv1.ECDSAWithSHA256,
+		defaultBits:   0,
+	}, nil
+}
+
+func createURI(rawuri string) (string, error) {
+	u, err := uri.ParseWithScheme(Scheme, rawuri)
+	if err != nil {
+		return "", err
+	}
+	var name string
+	if name = u.Get("name"); name == "" {
+		return "", fmt.Errorf("error parsing %q: name is required", rawuri)
+	}
+	v := url.Values{
+		"label": []string{name},
+	}
+	if u.GetBool("ak") {
+		v.Set("se", "true")
+	}
+	return uri.New(mackms.Scheme, v).String(), nil
+}

--- a/kms/platform/platform_others.go
+++ b/kms/platform/platform_others.go
@@ -1,0 +1,19 @@
+//go:build !linux && !windows && !darwin
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"go.step.sm/crypto/kms/apiv1"
+)
+
+func newKMS(context.Context, apiv1.Options) (*KMS, error) {
+	return nil, fmt.Errorf("error initializing kms: %s is not supported", runtime.GOOS)
+}
+
+func createURI(rawuri string) (string, error) {
+	panic(fmt.Errorf("%s is not supported", runtime.GOOS))
+}

--- a/kms/platform/platform_tpm.go
+++ b/kms/platform/platform_tpm.go
@@ -1,0 +1,43 @@
+//go:build linux || windows
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.step.sm/crypto/kms/apiv1"
+	"go.step.sm/crypto/kms/tpmkms"
+	"go.step.sm/crypto/kms/uri"
+)
+
+func newKMS(ctx context.Context, o apiv1.Options) (*KMS, error) {
+	k, err := tpmkms.New(ctx, apiv1.Options{
+		Type:             o.Type,
+		URI:              strings.Replace(o.URI, "kms:", "tpmkms:", 1),
+		StorageDirectory: o.StorageDirectory,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error initializing tpmkms: %w", err)
+	}
+	// On TPMs the real signature algorithm will be determined at sign time,
+	// we only need to define one that will create an RSA key.
+	return &KMS{
+		backend:       k,
+		defaultSigAlg: apiv1.SHA256WithRSA,
+		defaultBits:   2048,
+	}, nil
+}
+
+func createURI(rawuri string) (string, error) {
+	u, err := uri.ParseWithScheme(Scheme, rawuri)
+	if err != nil {
+		return "", err
+	}
+	var name string
+	if name = u.Get("name"); name == "" {
+		return "", fmt.Errorf("error parsing %q: name is required", rawuri)
+	}
+	return uri.New(tpmkms.Scheme, u.Values).String(), nil
+}


### PR DESCRIPTION
This PR adds support for a kms that uses a different implementation depending on the OS. It currently uses mackms on macOS and tpmkms on Linux and Windows.

This is a WIP
