### PR TITLE
Implement DeleteKey on tpmkms

### DIFF
--- a/keyutil/key.go
+++ b/keyutil/key.go
@@ -219,8 +219,8 @@ func generateECKey(crv string) (crypto.Signer, error) {
 }
 
 func generateRSAKey(bits int) (crypto.Signer, error) {
-	if min := MinRSAKeyBytes * 8; !insecureMode.isSet() && bits < min {
-		return nil, errors.Errorf("the size of the RSA key should be at least %d bits", min)
+	if minBits := MinRSAKeyBytes * 8; !insecureMode.isSet() && bits < minBits {
+		return nil, errors.Errorf("the size of the RSA key should be at least %d bits", minBits)
 	}
 
 	key, err := rsa.GenerateKey(rand.Reader, bits)


### PR DESCRIPTION
This commit implements the experimental DeleteKey in the `tpmkms`. It also converts all `tpm.ErrNotFound` to `apiv1.NotFoundError{}` and fixes a linter warning in keyutil.
