### PR TITLE
tpm/storage: Blackhole rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage.cov
 
 # Dependency directories (remove the comment below to include it)
 /vendor
+
+# Direnv file
+/.envrc

--- a/tpm/storage/blackhole.go
+++ b/tpm/storage/blackhole.go
@@ -1,12 +1,19 @@
 package storage
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
-// BlackHole returns a FeedthroughStore without a backing
-// storage, effectively resulting in no persistence.
-func BlackHole() TPMStore {
-	return NewFeedthroughStore(nil)
-}
+var (
+	errBlackHole = errors.New("blackhole: no tpm store configured")
+
+	bh TPMStore = blackHole{}
+)
+
+// BlackHole returns a [TMPStorage] that reports an appropriate error for all calls it is not
+// able to support.
+func BlackHole() TPMStore { return bh }
 
 // BlackholeContext adds a new BlackHole storage to the context.
 func BlackHoleContext(ctx context.Context) context.Context {
@@ -16,3 +23,33 @@ func BlackHoleContext(ctx context.Context) context.Context {
 	ctx = NewContext(ctx, BlackHole())
 	return ctx
 }
+
+type blackHole struct{}
+
+func (blackHole) ListKeys() ([]*Key, error) { return nil, nil }
+
+func (blackHole) ListKeyNames() []string { return nil }
+
+func (blackHole) GetKey(string) (*Key, error) { return nil, ErrNotFound }
+
+func (blackHole) AddKey(*Key) error { return errBlackHole }
+
+func (blackHole) UpdateKey(*Key) error { return errBlackHole }
+
+func (blackHole) DeleteKey(string) error { return ErrNotFound }
+
+func (blackHole) ListAKs() ([]*AK, error) { return nil, nil }
+
+func (blackHole) ListAKNames() []string { return nil }
+
+func (blackHole) GetAK(string) (*AK, error) { return nil, ErrNotFound }
+
+func (blackHole) AddAK(*AK) error { return errBlackHole }
+
+func (blackHole) UpdateAK(*AK) error { return errBlackHole }
+
+func (blackHole) DeleteAK(string) error { return ErrNotFound }
+
+func (blackHole) Persist() error { return errBlackHole }
+
+func (blackHole) Load() error { return nil }

--- a/tpm/storage/blackhole_test.go
+++ b/tpm/storage/blackhole_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +18,69 @@ func TestBlackHoleContext(t *testing.T) {
 	got = BlackHoleContext(context.TODO())
 	require.NotNil(t, got)
 	require.NotNil(t, FromContext(got))
+}
+
+func TestBlackHoleListKeys(t *testing.T) {
+	got, err := BlackHole().ListKeys()
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestBlackHoleListKeyNames(t *testing.T) {
+	assert.Empty(t, BlackHole().ListKeyNames())
+}
+
+func TestBlackHoleGetKey(t *testing.T) {
+	got, err := BlackHole().GetKey("some-key")
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, got)
+}
+
+func TestBlackHoleAddKey(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().AddKey(&Key{}), errBlackHole)
+}
+
+func TestBlackHoleUpdateKey(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().UpdateKey(&Key{}), errBlackHole)
+}
+
+func TestBlackHoleDeleteKey(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().DeleteKey("some-key"), ErrNotFound)
+}
+
+func TestBlackHoleListAKs(t *testing.T) {
+	got, err := BlackHole().ListAKs()
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestBlackHoleListAKNames(t *testing.T) {
+	got := BlackHole().ListAKNames()
+	assert.Empty(t, got)
+}
+
+func TestBlackHoleGetAK(t *testing.T) {
+	got, err := BlackHole().GetAK("some-ak")
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, got)
+}
+
+func TestBlackHoleAddAK(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().AddAK(&AK{}), errBlackHole)
+}
+
+func TestBlackHoleUpdateAK(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().UpdateAK(&AK{}), errBlackHole)
+}
+
+func TestBlackHoleDeleteAK(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().DeleteAK("some-key"), ErrNotFound)
+}
+
+func TestBlackHolePersist(t *testing.T) {
+	assert.ErrorIs(t, BlackHole().Persist(), errBlackHole)
+}
+
+func TestBlackHoleLoad(t *testing.T) {
+	assert.NoError(t, BlackHole().Load())
 }


### PR DESCRIPTION
This PR reworks the `Blackhole` TPM store so that it returns a sentinel error for its mutations and always `ErrNotFound` for its queries.