### PR TITLE
Return a sentinel error when no storage is configured when required

### DIFF
--- a/tpm/ak.go
+++ b/tpm/ak.go
@@ -147,9 +147,9 @@ func (t *TPM) CreateAK(ctx context.Context, name string) (ak *AK, err error) {
 	_, err = t.store.GetAK(name)
 	switch {
 	case errors.Is(err, storage.ErrNoStorageConfigured):
-		return nil, fmt.Errorf("failed creating new AK %q: %w", name, ErrNoStorageConfigured)
+		return nil, fmt.Errorf("failed creating AK %q: %w", name, ErrNoStorageConfigured)
 	case err == nil:
-		return nil, fmt.Errorf("failed creating new AK %q: %w", name, ErrExists)
+		return nil, fmt.Errorf("failed creating AK %q: %w", name, ErrExists)
 	}
 
 	akConfig := attest.AKConfig{
@@ -157,7 +157,7 @@ func (t *TPM) CreateAK(ctx context.Context, name string) (ak *AK, err error) {
 	}
 	aak, err := t.attestTPM.NewAK(&akConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating new AK %q: %w", name, err)
+		return nil, fmt.Errorf("failed creating AK %q: %w", name, err)
 	}
 	defer aak.Close(t.attestTPM)
 

--- a/tpm/ak.go
+++ b/tpm/ak.go
@@ -144,8 +144,12 @@ func (t *TPM) CreateAK(ctx context.Context, name string) (ak *AK, err error) {
 		return nil, err
 	}
 
-	if _, err := t.store.GetAK(name); err == nil {
+	_, err = t.store.GetAK(name)
+	switch {
+	case err == nil:
 		return nil, fmt.Errorf("failed creating AK %q: %w", name, ErrExists)
+	case errors.Is(err, storage.ErrNoStorageConfigured):
+		return nil, fmt.Errorf("failed creating key %q: %w", name, err)
 	}
 
 	akConfig := attest.AKConfig{

--- a/tpm/ak_test.go
+++ b/tpm/ak_test.go
@@ -46,7 +46,7 @@ func TestAK_MarshalJSON(t *testing.T) {
 	data, err := json.Marshal(ak)
 	require.NoError(t, err)
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 
@@ -65,12 +65,12 @@ func TestAK_MarshalJSON(t *testing.T) {
 	data, err = json.Marshal(ak)
 	require.NoError(t, err)
 
-	m = map[string]interface{}{}
+	m = map[string]any{}
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 
 	require.Equal(t, m["name"], ak.name)
 	require.Equal(t, m["data"], base64.StdEncoding.EncodeToString(ak.data))
-	require.Equal(t, m["chain"], []interface{}{base64.StdEncoding.EncodeToString(cert.Raw), base64.StdEncoding.EncodeToString(ca.Intermediate.Raw)})
+	require.Equal(t, m["chain"], []any{base64.StdEncoding.EncodeToString(cert.Raw), base64.StdEncoding.EncodeToString(ca.Intermediate.Raw)})
 	require.Equal(t, m["createdAt"], ak.createdAt.Format("2006-01-02T15:04:05Z"))
 }

--- a/tpm/attestation/client_test.go
+++ b/tpm/attestation/client_test.go
@@ -25,7 +25,7 @@ func TestNewClient(t *testing.T) {
 				tpmAttestationCABaseURL: baseURL,
 				options:                 nil,
 			},
-			assertFunc: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
+			assertFunc: func(tt assert.TestingT, i1 any, i2 ...any) bool {
 				if assert.IsType(t, &Client{}, i1) {
 					c, _ := i1.(*Client)
 					if assert.NotNil(t, c) {
@@ -48,7 +48,7 @@ func TestNewClient(t *testing.T) {
 				tpmAttestationCABaseURL: baseURL,
 				options:                 []Option{WithInsecure(), WithRootsFile("testdata/roots.pem")},
 			},
-			assertFunc: func(tt assert.TestingT, i1 interface{}, i2 ...interface{}) bool {
+			assertFunc: func(tt assert.TestingT, i1 any, i2 ...any) bool {
 				if assert.IsType(t, &Client{}, i1) {
 					c, _ := i1.(*Client)
 					if assert.NotNil(t, c) {

--- a/tpm/ek_test.go
+++ b/tpm/ek_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.step.sm/crypto/keyutil"
 	"go.step.sm/crypto/minica"
 	"go.step.sm/crypto/x509util"
@@ -71,7 +72,7 @@ func TestEK_MarshalJSON(t *testing.T) {
 	data, err := json.Marshal(ek)
 	require.NoError(t, err)
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 

--- a/tpm/errors.go
+++ b/tpm/errors.go
@@ -1,6 +1,10 @@
 package tpm
 
-import "errors"
+import (
+	"errors"
+
+	"go.step.sm/crypto/tpm/storage"
+)
 
 // ErrNotFound is returned when a Key or AK cannot be found
 var ErrNotFound = errors.New("not found")
@@ -10,4 +14,4 @@ var ErrExists = errors.New("already exists")
 
 // ErrNoStorageConfigured is returned when a TPM operation is
 // performed that requires a storage to have been configured
-var ErrNoStorageConfigured = errors.New("no storage configured")
+var ErrNoStorageConfigured = storage.ErrNoStorageConfigured

--- a/tpm/errors.go
+++ b/tpm/errors.go
@@ -7,3 +7,7 @@ var ErrNotFound = errors.New("not found")
 
 // ErrExists is returned when a Key or AK already exists
 var ErrExists = errors.New("already exists")
+
+// ErrNoStorageConfigured is returned when a TPM operation is
+// performed that requires a storage to have been configured
+var ErrNoStorageConfigured = errors.New("no storage configured")

--- a/tpm/key.go
+++ b/tpm/key.go
@@ -226,10 +226,10 @@ func (t *TPM) AttestKey(ctx context.Context, akName, name string, config AttestK
 
 	_, err = t.store.GetKey(name)
 	switch {
-	case errors.Is(err, storage.ErrNoStorageConfigured):
-		return nil, fmt.Errorf("failed creating key %q: %w", name, err)
 	case err == nil:
 		return nil, fmt.Errorf("failed creating key %q: %w", name, ErrExists)
+	case errors.Is(err, storage.ErrNoStorageConfigured):
+		return nil, fmt.Errorf("failed creating key %q: %w", name, err)
 	}
 
 	ak, err := t.store.GetAK(akName)

--- a/tpm/key.go
+++ b/tpm/key.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/smallstep/go-attestation/attest"
+
 	internalkey "go.step.sm/crypto/tpm/internal/key"
 	"go.step.sm/crypto/tpm/storage"
 )
@@ -156,10 +157,10 @@ func (t *TPM) CreateKey(ctx context.Context, name string, config CreateKeyConfig
 
 	_, err = t.store.GetKey(name)
 	switch {
-	case errors.Is(err, storage.ErrNoStorageConfigured):
-		return nil, fmt.Errorf("failed creating key %q: %w", name, ErrNoStorageConfigured)
 	case err == nil:
 		return nil, fmt.Errorf("failed creating key %q: %w", name, ErrExists)
+	case errors.Is(err, storage.ErrNoStorageConfigured):
+		return nil, fmt.Errorf("failed creating key %q: %w", name, err)
 	}
 
 	createConfig := internalkey.CreateConfig{
@@ -182,9 +183,6 @@ func (t *TPM) CreateKey(ctx context.Context, name string, config CreateKeyConfig
 	}
 
 	if err := t.store.AddKey(key.toStorage()); err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return nil, fmt.Errorf("failed adding key %q to storage: %w", name, ErrNoStorageConfigured)
-		}
 		return nil, fmt.Errorf("failed adding key %q to storage: %w", name, err)
 	}
 
@@ -229,21 +227,17 @@ func (t *TPM) AttestKey(ctx context.Context, akName, name string, config AttestK
 	_, err = t.store.GetKey(name)
 	switch {
 	case errors.Is(err, storage.ErrNoStorageConfigured):
-		return nil, fmt.Errorf("failed creating key %q: %w", name, ErrNoStorageConfigured)
+		return nil, fmt.Errorf("failed creating key %q: %w", name, err)
 	case err == nil:
 		return nil, fmt.Errorf("failed creating key %q: %w", name, ErrExists)
 	}
 
 	ak, err := t.store.GetAK(akName)
 	if err != nil {
-		switch {
-		case errors.Is(err, storage.ErrNotFound):
+		if errors.Is(err, storage.ErrNotFound) {
 			return nil, fmt.Errorf("failed getting AK %q: %w", akName, ErrNotFound)
-		case errors.Is(err, storage.ErrNoStorageConfigured):
-			return nil, fmt.Errorf("failed getting AK %q: %w", akName, ErrNoStorageConfigured)
-		default:
-			return nil, fmt.Errorf("failed getting AK %q: %w", akName, err)
 		}
+		return nil, fmt.Errorf("failed getting AK %q: %w", akName, err)
 	}
 
 	loadedAK, err := t.attestTPM.LoadAK(ak.Data)
@@ -281,9 +275,6 @@ func (t *TPM) AttestKey(ctx context.Context, akName, name string, config AttestK
 	}
 
 	if err := t.store.AddKey(key.toStorage()); err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return nil, fmt.Errorf("failed adding key %q to storage: %w", name, ErrNoStorageConfigured)
-		}
 		return nil, fmt.Errorf("failed adding key %q to storage: %w", name, err)
 	}
 
@@ -304,14 +295,10 @@ func (t *TPM) GetKey(ctx context.Context, name string) (key *Key, err error) {
 
 	skey, err := t.store.GetKey(name)
 	if err != nil {
-		switch {
-		case errors.Is(err, storage.ErrNotFound):
+		if errors.Is(err, storage.ErrNotFound) {
 			return nil, fmt.Errorf("failed getting key %q: %w", name, ErrNotFound)
-		case errors.Is(err, storage.ErrNoStorageConfigured):
-			return nil, fmt.Errorf("failed getting key %q: %w", name, ErrNoStorageConfigured)
-		default:
-			return nil, fmt.Errorf("failed getting key %q: %w", name, err)
 		}
+		return nil, fmt.Errorf("failed getting key %q: %w", name, err)
 	}
 
 	return keyFromStorage(skey, t), nil
@@ -327,9 +314,6 @@ func (t *TPM) ListKeys(ctx context.Context) (keys []*Key, err error) {
 
 	skeys, err := t.store.ListKeys()
 	if err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return nil, fmt.Errorf("failed listing keys: %w", ErrNoStorageConfigured)
-		}
 		return nil, fmt.Errorf("failed listing keys: %w", err)
 	}
 
@@ -351,9 +335,6 @@ func (t *TPM) GetKeysAttestedBy(ctx context.Context, akName string) (keys []*Key
 
 	skeys, err := t.store.ListKeys()
 	if err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return nil, fmt.Errorf("failed listing keys: %w", ErrNoStorageConfigured)
-		}
 		return nil, fmt.Errorf("failed listing keys: %w", err)
 	}
 
@@ -377,14 +358,10 @@ func (t *TPM) DeleteKey(ctx context.Context, name string) (err error) {
 
 	key, err := t.store.GetKey(name)
 	if err != nil {
-		switch {
-		case errors.Is(err, storage.ErrNotFound):
+		if errors.Is(err, storage.ErrNotFound) {
 			return fmt.Errorf("failed getting key %q: %w", name, ErrNotFound)
-		case errors.Is(err, storage.ErrNoStorageConfigured):
-			return fmt.Errorf("failed getting key %q: %w", name, ErrNoStorageConfigured)
-		default:
-			return fmt.Errorf("failed getting key %q: %w", name, err)
 		}
+		return fmt.Errorf("failed getting key %q: %w", name, err)
 	}
 
 	if err := t.attestTPM.DeleteKey(key.Data); err != nil {
@@ -392,9 +369,6 @@ func (t *TPM) DeleteKey(ctx context.Context, name string) (err error) {
 	}
 
 	if err := t.store.DeleteKey(name); err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return fmt.Errorf("failed deleting key %q from storage: %w", name, ErrNoStorageConfigured)
-		}
 		return fmt.Errorf("failed deleting key %q from storage: %w", name, err)
 	}
 
@@ -493,9 +467,6 @@ func (k *Key) SetCertificateChain(ctx context.Context, chain []*x509.Certificate
 	k.chain = chain // TODO(hs): deep copy, so that certs can't be changed by pointer?
 
 	if err := k.tpm.store.UpdateKey(k.toStorage()); err != nil {
-		if errors.Is(err, storage.ErrNoStorageConfigured) {
-			return fmt.Errorf("failed updating key %q: %w", k.name, ErrNoStorageConfigured)
-		}
 		return fmt.Errorf("failed updating key %q: %w", k.name, err)
 	}
 

--- a/tpm/key_test.go
+++ b/tpm/key_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestKey_MarshalJSON(t *testing.T) {
-
 	ca, err := minica.New(
 		minica.WithGetSignerFunc(
 			func() (crypto.Signer, error) {
@@ -48,7 +47,7 @@ func TestKey_MarshalJSON(t *testing.T) {
 	data, err := json.Marshal(key)
 	require.NoError(t, err)
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 
@@ -69,13 +68,13 @@ func TestKey_MarshalJSON(t *testing.T) {
 	data, err = json.Marshal(key)
 	require.NoError(t, err)
 
-	m = map[string]interface{}{}
+	m = map[string]any{}
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 
 	require.Equal(t, m["name"], key.name)
 	require.Equal(t, m["data"], base64.StdEncoding.EncodeToString(key.data))
 	require.Equal(t, m["attestedBy"], key.attestedBy)
-	require.Equal(t, m["chain"], []interface{}{base64.StdEncoding.EncodeToString(cert.Raw), base64.StdEncoding.EncodeToString(ca.Intermediate.Raw)})
+	require.Equal(t, m["chain"], []any{base64.StdEncoding.EncodeToString(cert.Raw), base64.StdEncoding.EncodeToString(ca.Intermediate.Raw)})
 	require.Equal(t, m["createdAt"], key.createdAt.Format("2006-01-02T15:04:05Z"))
 }

--- a/tpm/signer.go
+++ b/tpm/signer.go
@@ -62,10 +62,14 @@ func (t *TPM) GetSigner(ctx context.Context, name string) (csigner crypto.Signer
 
 	key, err := t.store.GetKey(name)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
+		switch {
+		case errors.Is(err, storage.ErrNotFound):
 			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, ErrNotFound)
+		case errors.Is(err, storage.ErrNoStorageConfigured):
+			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, ErrNoStorageConfigured)
+		default:
+			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, err)
 		}
-		return nil, err
 	}
 
 	loadedKey, err := t.attestTPM.LoadKey(key.Data)

--- a/tpm/signer.go
+++ b/tpm/signer.go
@@ -62,12 +62,10 @@ func (t *TPM) GetSigner(ctx context.Context, name string) (csigner crypto.Signer
 
 	key, err := t.store.GetKey(name)
 	if err != nil {
-		switch {
-		case errors.Is(err, storage.ErrNotFound):
+		if errors.Is(err, storage.ErrNotFound) {
 			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, ErrNotFound)
-		default:
-			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, err)
 		}
+		return nil, fmt.Errorf("failed getting signer for key %q: %w", name, err)
 	}
 
 	loadedKey, err := t.attestTPM.LoadKey(key.Data)

--- a/tpm/signer.go
+++ b/tpm/signer.go
@@ -65,8 +65,6 @@ func (t *TPM) GetSigner(ctx context.Context, name string) (csigner crypto.Signer
 		switch {
 		case errors.Is(err, storage.ErrNotFound):
 			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, ErrNotFound)
-		case errors.Is(err, storage.ErrNoStorageConfigured):
-			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, ErrNoStorageConfigured)
 		default:
 			return nil, fmt.Errorf("failed getting signer for key %q: %w", name, err)
 		}

--- a/tpm/storage/blackhole.go
+++ b/tpm/storage/blackhole.go
@@ -2,8 +2,11 @@ package storage
 
 import "context"
 
-// BlackHole returns a FeedthroughStore without a backing
-// storage, effectively resulting in no persistence.
+// BlackHole returns a [FeedthroughStore] without a backing
+// storage, effectively resulting in no persistence. Note
+// that some operations do require persistence, in which
+// case [ErrNoStorageConfigured] will be returned by the
+// [FeedthroughStore].
 func BlackHole() TPMStore {
 	return NewFeedthroughStore(nil)
 }

--- a/tpm/storage/blackhole_test.go
+++ b/tpm/storage/blackhole_test.go
@@ -18,3 +18,34 @@ func TestBlackHoleContext(t *testing.T) {
 	require.NotNil(t, got)
 	require.NotNil(t, FromContext(got))
 }
+
+func TestBlackHole(t *testing.T) {
+	t.Parallel()
+
+	store := BlackHole()
+	err := store.AddAK(&AK{Name: "ak"})
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+
+	k, err := store.GetAK("ak")
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Nil(t, k)
+
+	err = store.UpdateAK(k)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+
+	names := store.ListAKNames()
+	require.Empty(t, names)
+
+	aks, err := store.ListAKs()
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Empty(t, aks)
+
+	err = store.DeleteAK("ak")
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+
+	err = store.Persist()
+	require.NoError(t, err)
+
+	err = store.Load()
+	require.NoError(t, err)
+}

--- a/tpm/storage/dirstore.go
+++ b/tpm/storage/dirstore.go
@@ -10,10 +10,10 @@ import (
 	"github.com/peterbourgon/diskv/v3"
 )
 
-// Dirstore is a concrete implementation of the TPMStore interface that
+// Dirstore is a concrete implementation of the [TPMStore] interface that
 // stores TPM objects in a directory. Each object will be stored in a
-// separate file. The name of the file is constructed by prefixing the
-// name of the object with its type.
+// separate file in the directory. The name of the file is constructed
+// by prefixing the name of the object with its type.
 type Dirstore struct {
 	store     *diskv.Diskv
 	directory string

--- a/tpm/storage/dirstore_test.go
+++ b/tpm/storage/dirstore_test.go
@@ -74,10 +74,10 @@ func TestDirstore_KeyOperations(t *testing.T) {
 
 	err = store.DeleteKey("1st-key")
 	require.NoError(t, err)
+
 	keys, err = store.ListKeys()
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*Key{key2}, keys)
-
 }
 
 func TestDirstore_AKOperations(t *testing.T) {
@@ -117,8 +117,8 @@ func TestDirstore_AKOperations(t *testing.T) {
 
 	err = store.DeleteAK("1st-ak")
 	require.NoError(t, err)
+
 	aks, err = store.ListAKs()
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*AK{ak2}, aks)
-
 }

--- a/tpm/storage/errors.go
+++ b/tpm/storage/errors.go
@@ -9,3 +9,7 @@ var ErrNotFound = errors.New("not found")
 
 // ErrExists is returned when a Key or AK already exists in storage
 var ErrExists = errors.New("already exists")
+
+// ErrNoStorageConfigured is returned when a TPM operation is
+// performed that requires a storage to have been configured
+var ErrNoStorageConfigured = errors.New("no storage configured")

--- a/tpm/storage/feedthrough.go
+++ b/tpm/storage/feedthrough.go
@@ -1,8 +1,8 @@
 package storage
 
 // FeedthroughStore is a TPMStore that feeds through storage operations
-// to the underlying TPMStore. If no backing TPMStore is set, the operations
-// effectively become NOOPs.
+// to the underlying TPMStore. If no backing TPMStore is set, but the
+// operation requires one, [ErrNoStorageConfigured] will be returned.
 type FeedthroughStore struct {
 	store TPMStore
 }

--- a/tpm/storage/feedthrough.go
+++ b/tpm/storage/feedthrough.go
@@ -15,84 +15,84 @@ func NewFeedthroughStore(store TPMStore) *FeedthroughStore {
 
 func (f *FeedthroughStore) ListKeys() ([]*Key, error) {
 	if f.store == nil {
-		return nil, nil
+		return nil, ErrNoStorageConfigured
 	}
 	return f.store.ListKeys()
 }
 
 func (f *FeedthroughStore) ListKeyNames() []string {
 	if f.store == nil {
-		return []string{}
+		return nil
 	}
 	return f.store.ListKeyNames()
 }
 
 func (f *FeedthroughStore) GetKey(name string) (*Key, error) {
 	if f.store == nil {
-		return nil, nil //nolint:nilnil // intentional noop
+		return nil, ErrNoStorageConfigured
 	}
 	return f.store.GetKey(name)
 }
 
 func (f *FeedthroughStore) AddKey(key *Key) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.AddKey(key)
 }
 
 func (f *FeedthroughStore) UpdateKey(key *Key) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.UpdateKey(key)
 }
 
 func (f *FeedthroughStore) DeleteKey(name string) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.DeleteKey(name)
 }
 
 func (f *FeedthroughStore) ListAKs() ([]*AK, error) {
 	if f.store == nil {
-		return nil, nil
+		return nil, ErrNoStorageConfigured
 	}
 	return f.store.ListAKs()
 }
 
 func (f *FeedthroughStore) ListAKNames() []string {
 	if f.store == nil {
-		return []string{}
+		return nil
 	}
 	return f.store.ListAKNames()
 }
 
 func (f *FeedthroughStore) GetAK(name string) (*AK, error) {
 	if f.store == nil {
-		return nil, nil //nolint:nilnil // intentional noop
+		return nil, ErrNoStorageConfigured
 	}
 	return f.store.GetAK(name)
 }
 
 func (f *FeedthroughStore) AddAK(ak *AK) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.AddAK(ak)
 }
 
 func (f *FeedthroughStore) UpdateAK(ak *AK) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.UpdateAK(ak)
 }
 
 func (f *FeedthroughStore) DeleteAK(name string) error {
 	if f.store == nil {
-		return nil
+		return ErrNoStorageConfigured
 	}
 	return f.store.DeleteAK(name)
 }

--- a/tpm/storage/feedthrough_test.go
+++ b/tpm/storage/feedthrough_test.go
@@ -15,40 +15,47 @@ func TestFeedthroughStore_NilKeyOperations(t *testing.T) {
 	key2 := &Key{Name: "2nd-key"}
 
 	err := store.AddKey(key1)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.AddKey(key2)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.AddKey(&Key{Name: "1st-key"})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	k, err := store.GetKey("1st-key")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 	require.Nil(t, k)
 
 	err = store.UpdateKey(k)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	k, err = store.GetKey("3rd-key")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 	require.Nil(t, k)
 
 	names := store.ListKeyNames()
-	require.Equal(t, []string{}, names)
+	require.Empty(t, names)
 
 	keys, err := store.ListKeys()
-	require.NoError(t, err)
-	require.ElementsMatch(t, []*Key{}, keys)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Empty(t, keys)
 
 	err = store.DeleteKey("3rd-key")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.DeleteKey("1st-key")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+
 	keys, err = store.ListKeys()
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Empty(t, keys)
+
+	err = store.Persist()
 	require.NoError(t, err)
-	require.ElementsMatch(t, []*Key{}, keys)
+
+	err = store.Load()
+	require.NoError(t, err)
 }
 
 func TestFeedthroughStore_KeyOperations(t *testing.T) {
@@ -97,9 +104,16 @@ func TestFeedthroughStore_KeyOperations(t *testing.T) {
 
 	err = store.DeleteKey("1st-key")
 	require.NoError(t, err)
+
 	keys, err = store.ListKeys()
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*Key{key2}, keys)
+
+	err = store.Persist()
+	require.NoError(t, err)
+
+	err = store.Load()
+	require.NoError(t, err)
 }
 
 func TestFeedthroughStore_NilAKOperations(t *testing.T) {
@@ -111,40 +125,47 @@ func TestFeedthroughStore_NilAKOperations(t *testing.T) {
 	ak2 := &AK{Name: "2nd-ak"}
 
 	err := store.AddAK(ak1)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.AddAK(ak2)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.AddAK(&AK{Name: "1st-ak"})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	k, err := store.GetAK("1st-ak")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 	require.Nil(t, k)
 
 	err = store.UpdateAK(k)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	k, err = store.GetAK("3rd-ak")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 	require.Nil(t, k)
 
 	names := store.ListAKNames()
-	require.Equal(t, []string{}, names)
+	require.Empty(t, names)
 
 	aks, err := store.ListAKs()
-	require.NoError(t, err)
-	require.ElementsMatch(t, []*AK{}, aks)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Empty(t, aks)
 
 	err = store.DeleteAK("3rd-ak")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
 
 	err = store.DeleteAK("1st-ak")
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+
 	aks, err = store.ListAKs()
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.Empty(t, aks)
+
+	err = store.Persist()
 	require.NoError(t, err)
-	require.ElementsMatch(t, []*AK{}, aks)
+
+	err = store.Load()
+	require.NoError(t, err)
 }
 
 func TestFeedthroughStore_AKOperations(t *testing.T) {
@@ -193,7 +214,14 @@ func TestFeedthroughStore_AKOperations(t *testing.T) {
 
 	err = store.DeleteAK("1st-ak")
 	require.NoError(t, err)
+
 	aks, err = store.ListAKs()
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*AK{ak2}, aks)
+
+	err = store.Persist()
+	require.NoError(t, err)
+
+	err = store.Load()
+	require.NoError(t, err)
 }

--- a/tpm/storage/types_test.go
+++ b/tpm/storage/types_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"go.step.sm/crypto/keyutil"
 	"go.step.sm/crypto/minica"
 	"go.step.sm/crypto/x509util"
 )
 
 func TestAK_MarshalUnmarshal(t *testing.T) {
-
 	ca, err := minica.New()
 	require.NoError(t, err)
 
@@ -47,7 +47,6 @@ func TestAK_MarshalUnmarshal(t *testing.T) {
 }
 
 func TestKey_MarshalUnmarshal(t *testing.T) {
-
 	ca, err := minica.New()
 	require.NoError(t, err)
 

--- a/tpm/tpm.go
+++ b/tpm/tpm.go
@@ -86,6 +86,8 @@ func WithSimulator(sim simulator.Simulator) NewTPMOption {
 
 type CommandChannel attest.CommandChannelTPM20
 
+// WithCommandChannel is used to configure a [CommandChannel] as the
+// interface to interact with instead of with an actual TPM.
 func WithCommandChannel(commandChannel CommandChannel) NewTPMOption {
 	return func(o *options) error {
 		o.commandChannel = commandChannel
@@ -110,7 +112,10 @@ func (o *options) validate() error {
 }
 
 // New creates a new TPM instance. It takes `opts` to configure
-// the instance.
+// the instance. By default it uses a blackhole storage, meaning
+// that there's no actual persistence. Some operations require
+// an actual persistence mechanism, and will return an error if
+// none is configured.
 func New(opts ...NewTPMOption) (*TPM, error) {
 	tpmOptions := options{
 		attestConfig: &attest.OpenConfig{TPMVersion: attest.TPMVersion20},                      // default configuration for TPM attestation use cases

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"go.step.sm/crypto/tpm/storage"
 )
 
 type closeSimulator struct {
@@ -73,4 +75,10 @@ func Test_close(t *testing.T) {
 	require.Nil(t, tpm.simulator)
 	closeTPM(context.Background(), newCloseErrorTPM(t), &closeErr)
 	require.EqualError(t, closeErr, "failed closing attest.TPM: closeErr") // attest.TPM is backed by the closeSimulator
+}
+
+func TestTPMNoStorageConfiguredError(t *testing.T) {
+	err := ErrNoStorageConfigured
+	require.ErrorIs(t, err, ErrNoStorageConfigured)
+	require.ErrorIs(t, err, storage.ErrNoStorageConfigured)
 }

--- a/tpm/tpm_test.go
+++ b/tpm/tpm_test.go
@@ -79,6 +79,5 @@ func Test_close(t *testing.T) {
 
 func TestTPMNoStorageConfiguredError(t *testing.T) {
 	err := ErrNoStorageConfigured
-	require.ErrorIs(t, err, ErrNoStorageConfigured)
 	require.ErrorIs(t, err, storage.ErrNoStorageConfigured)
 }

--- a/tpm/tss2/signer_test.go
+++ b/tpm/tss2/signer_test.go
@@ -55,7 +55,7 @@ var defaultKeyParamsRSAPSS = tpm2.Public{
 	},
 }
 
-func assertMaybeError(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+func assertMaybeError(t assert.TestingT, err error, msgAndArgs ...any) bool {
 	return true
 }
 


### PR DESCRIPTION
The goal of the blackhole storage is to be able to use an instance of `tpm.TPM` for operations that don't require an (metadata) storage. In some usages it could result in an error or even a panic, because it's not clear enough that some operations require an actual storage implementation for the operations to succeed. 

This commit changes the behavior of the blackhole storage. It now returns a sentinel error for operations that require a storage to be successful. The sentinel error is handled in the `tpm` package wherever a storage operation takes place.
