### PR TITLE
feat: introduce AWS KMS types.MessageTypeRaw for AWS KMS signing operations

### DIFF
--- a/kms/awskms/signer_test.go
+++ b/kms/awskms/signer_test.go
@@ -125,7 +125,9 @@ func TestSigner_Sign(t *testing.T) {
 		wantErr bool
 	}{
 		{"ok", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", key}, args{rand.Reader, []byte("digest"), crypto.SHA256}, signature, false},
-		{"fail alg", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", key}, args{rand.Reader, []byte("digest"), crypto.MD5}, nil, true},
+		{"(raw) ok", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", key}, args{rand.Reader, []byte("digest"), &AWSOptions{Raw: true, Options: crypto.SHA256}}, signature, false},
+		{"fail alg", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", key}, args{rand.Reader, []byte("digest"), &AWSOptions{Raw: true, Options: crypto.MD5}}, nil, true},
+		{"(raw) fail alg", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", key}, args{rand.Reader, []byte("digest"), crypto.MD5}, nil, true},
 		{"fail key", fields{okClient, "be468355-ca7a-40d9-a28b-8ae1c4c7f936", []byte("key")}, args{rand.Reader, []byte("digest"), crypto.SHA256}, nil, true},
 		{"fail sign", fields{&MockClient{
 			sign: func(ctx context.Context, input *kms.SignInput, opts ...func(*kms.Options)) (*kms.SignOutput, error) {
@@ -152,39 +154,52 @@ func TestSigner_Sign(t *testing.T) {
 	}
 }
 
-func Test_getSigningAlgorithm(t *testing.T) {
+func Test_getMessageTypeAndSigningAlgorithm(t *testing.T) {
 	type args struct {
 		key  crypto.PublicKey
 		opts crypto.SignerOpts
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    types.SigningAlgorithmSpec
-		wantErr bool
+		name            string
+		args            args
+		wantMessageType types.MessageType
+		wantAlgo        types.SigningAlgorithmSpec
+		wantErr         bool
 	}{
-		{"rsa+sha256", args{&rsa.PublicKey{}, crypto.SHA256}, "RSASSA_PKCS1_V1_5_SHA_256", false},
-		{"rsa+sha384", args{&rsa.PublicKey{}, crypto.SHA384}, "RSASSA_PKCS1_V1_5_SHA_384", false},
-		{"rsa+sha512", args{&rsa.PublicKey{}, crypto.SHA512}, "RSASSA_PKCS1_V1_5_SHA_512", false},
-		{"pssrsa+sha256", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA256.HashFunc()}}, "RSASSA_PSS_SHA_256", false},
-		{"pssrsa+sha384", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA384.HashFunc()}}, "RSASSA_PSS_SHA_384", false},
-		{"pssrsa+sha512", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA512.HashFunc()}}, "RSASSA_PSS_SHA_512", false},
-		{"P256", args{&ecdsa.PublicKey{}, crypto.SHA256}, "ECDSA_SHA_256", false},
-		{"P384", args{&ecdsa.PublicKey{}, crypto.SHA384}, "ECDSA_SHA_384", false},
-		{"P521", args{&ecdsa.PublicKey{}, crypto.SHA512}, "ECDSA_SHA_512", false},
-		{"fail type", args{[]byte("key"), crypto.SHA256}, "", true},
-		{"fail rsa alg", args{&rsa.PublicKey{}, crypto.MD5}, "", true},
-		{"fail ecdsa alg", args{&ecdsa.PublicKey{}, crypto.MD5}, "", true},
+		{"rsa+sha256", args{&rsa.PublicKey{}, crypto.SHA256}, types.MessageTypeDigest, "RSASSA_PKCS1_V1_5_SHA_256", false},
+		{"rsa+sha384", args{&rsa.PublicKey{}, crypto.SHA384}, types.MessageTypeDigest, "RSASSA_PKCS1_V1_5_SHA_384", false},
+		{"rsa+sha512", args{&rsa.PublicKey{}, crypto.SHA512}, types.MessageTypeDigest, "RSASSA_PKCS1_V1_5_SHA_512", false},
+		{"pssrsa+sha256", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA256.HashFunc()}}, types.MessageTypeDigest, "RSASSA_PSS_SHA_256", false},
+		{"pssrsa+sha384", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA384.HashFunc()}}, types.MessageTypeDigest, "RSASSA_PSS_SHA_384", false},
+		{"pssrsa+sha512", args{&rsa.PublicKey{}, &rsa.PSSOptions{Hash: crypto.SHA512.HashFunc()}}, types.MessageTypeDigest, "RSASSA_PSS_SHA_512", false},
+		{"P256", args{&ecdsa.PublicKey{}, crypto.SHA256}, types.MessageTypeDigest, "ECDSA_SHA_256", false},
+		{"P384", args{&ecdsa.PublicKey{}, crypto.SHA384}, types.MessageTypeDigest, "ECDSA_SHA_384", false},
+		{"P521", args{&ecdsa.PublicKey{}, crypto.SHA512}, types.MessageTypeDigest, "ECDSA_SHA_512", false},
+		{"(raw)rsa+sha256", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA256}}, types.MessageTypeRaw, "RSASSA_PKCS1_V1_5_SHA_256", false},
+		{"(raw)rsa+sha384", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA384}}, types.MessageTypeRaw, "RSASSA_PKCS1_V1_5_SHA_384", false},
+		{"(raw)rsa+sha512", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA512}}, types.MessageTypeRaw, "RSASSA_PKCS1_V1_5_SHA_512", false},
+		{"(raw)pssrsa+sha256", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: &rsa.PSSOptions{Hash: crypto.SHA256.HashFunc()}}}, types.MessageTypeRaw, "RSASSA_PSS_SHA_256", false},
+		{"(raw)pssrsa+sha384", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: &rsa.PSSOptions{Hash: crypto.SHA384.HashFunc()}}}, types.MessageTypeRaw, "RSASSA_PSS_SHA_384", false},
+		{"(raw)pssrsa+sha512", args{&rsa.PublicKey{}, &AWSOptions{Raw: true, Options: &rsa.PSSOptions{Hash: crypto.SHA512.HashFunc()}}}, types.MessageTypeRaw, "RSASSA_PSS_SHA_512", false},
+		{"(raw)P256", args{&ecdsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA256}}, types.MessageTypeRaw, "ECDSA_SHA_256", false},
+		{"(raw)P384", args{&ecdsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA384}}, types.MessageTypeRaw, "ECDSA_SHA_384", false},
+		{"(raw)P521", args{&ecdsa.PublicKey{}, &AWSOptions{Raw: true, Options: crypto.SHA512}}, types.MessageTypeRaw, "ECDSA_SHA_512", false},
+		{"fail type", args{[]byte("key"), crypto.SHA256}, types.MessageTypeDigest, "", true},
+		{"fail rsa alg", args{&rsa.PublicKey{}, crypto.MD5}, types.MessageTypeDigest, "", true},
+		{"fail ecdsa alg", args{&ecdsa.PublicKey{}, crypto.MD5}, types.MessageTypeDigest, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getSigningAlgorithm(tt.args.key, tt.args.opts)
+			gotMessageType, gotAlgo, err := getMessageTypeAndSigningAlgorithm(tt.args.key, tt.args.opts)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getSigningAlgorithm() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getMessageTypeAndSigningAlgorithm() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("getSigningAlgorithm() = %v, want %v", got, tt.want)
+			if gotMessageType != tt.wantMessageType {
+				t.Errorf("getMessageTypeAndSigningAlgorithm() (message type) = %v, want %v", gotMessageType, tt.wantMessageType)
+			}
+			if gotAlgo != tt.wantAlgo {
+				t.Errorf("getMessageTypeAndSigningAlgorithm() (algorithm) = %v, want %v", gotAlgo, tt.wantAlgo)
 			}
 		})
 	}


### PR DESCRIPTION
Hi `smallstep/crypto` reviewers! :wave:

This is my first contributing PR, please feel free to provide any feedback! I'm happy to change things up where required! 

#### Name of feature: 
Implement a means for callers to specify `types.MessageTypeRaw` in AWS KMS Sign operations.

#### Pain or issue this feature alleviates:
Currently, the `awskms.Sign` operation exclusively supports the signing of messages, where the message is expected to be a `types.MessageTypeDigest`. 

This limitation prevents callers from being able to specify that their message is un-hashed, and thus unable to inform the AWS KMS API that the Sign operation should have a `types.MessageType` of `types.MessageTypeRaw` (`RAW`). 

##### Limitations 

The objective of this package, (and the other Signing packages) is to provide an implementation of the `crypto.Signer` interface that performs the relevant cloud based signing operations. 

As a part of the `crypto.Signer` interface, the `crypto.SignerOpts` interface is include as the third and final argument to the `Sign()` method. 

A perk of the `crypto.SignerOpts` interface is the promise that: 
```go
// HashFunc returns an identifier for the hash function used to produce
// the message passed to Signer.Sign, or else zero to indicate that no
// hashing was done.
HashFunc() Hash
```

However, within the `awskms` implementation of the `crypto.Signer` interface, this promise cannot be fulfilled, as the AWS KMS `Sign` operation requires a `types.SigningAlgorithmSpec` must be provided when performing an AWS KMS Signing operation. 

AWS KMS Go SDK v2 Documentation:
```go
// Specifies the signing algorithm to use when signing the message.
//
// Choose an algorithm that is compatible with the type and size of the specified
// asymmetric KMS key. When signing with RSA key pairs, RSASSA-PSS algorithms are
// preferred. We include RSASSA-PKCS1-v1_5 algorithms for compatibility with
// existing applications.
//
// This member is required.
SigningAlgorithm types.SigningAlgorithmSpec
```

The only exclusion to this limitation is when signing with ECDSA keys. As AWS does not enable the user to specify arbirtary signing algorithms, but rather the specified signing algorithm for that ECDSA key type. See [The ECDSA AWS Key Spec](https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-ecc)

As such, when calling the `awskms` `Sign()` we must **always** provide a non-zero `crypto.Hash` as our `crypto.SignerOpts` argument. 

##### Mitigation 

To mitigate this limitation, a new `AWSOptions` type is introduced to the `awskms` package. 

This `AWSOptions` type implements the `crypto.SignerOpts` interface, and allows callers to specify whether or not the message is `RAW`. 

Additionally, it posses a `crypto.SignerOpts` field `Options` where callers can provide the underlying `crypto.Hash` that can be matched with the appropriate `types.SigningAlgorithmSpec` that is expected by the AWS KMS Sign API.

##### Approach

I have opted to use a more generic `AWSOptions` struct with the `Raw` field as a boolean to indicate if the `types.MessageType` is `types.MessageTypeRaw` or not. I did consider using a struct such as `AWSRawMessageOptions` and removing the field (since the only logical difference is the truthy value of the `Raw` field.) However I decided against it such that we open ourselves up to adding or removing additional options in the future. 

#### Why is this important to the project (if not answered above):

Allow callers to have the additional flexibility of using both `types.MessageTypeRaw` and `types.MessageTypeDigest` when using the `awskms` Signer. 

#### Is there documentation on how to use this feature? If so, where?

GoDoc comments on the `awskms.AWSOptions` struct has been introduced.

#### In what environments or workflows is this feature supported?

AWS Environments that leverage AWS KMS Sign operations. 

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Non-AWS Environments.

#### Supporting links/other PRs/issues:

N/a