### PR TITLE
Remove extraneous 'CertFreeCertificateContext' in capi.

### DIFF
--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -791,7 +791,6 @@ func (k *CAPIKMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
 		if certHandle == nil {
 			return nil
 		}
-		defer windows.CertFreeCertificateContext(certHandle)
 
 		if err := windows.CertDeleteCertificateFromStore(certHandle); err != nil {
 			return fmt.Errorf("failed removing certificate: %w", err)
@@ -822,7 +821,6 @@ func (k *CAPIKMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
 		if certHandle == nil {
 			return nil
 		}
-		defer windows.CertFreeCertificateContext(certHandle)
 
 		if err := windows.CertDeleteCertificateFromStore(certHandle); err != nil {
 			return fmt.Errorf("failed removing certificate: %w", err)
@@ -862,10 +860,10 @@ func (k *CAPIKMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
 			if certHandle == nil {
 				return nil
 			}
-			defer windows.CertFreeCertificateContext(certHandle)
 
 			x509Cert, err := certContextToX509(certHandle)
 			if err != nil {
+				defer windows.CertFreeCertificateContext(certHandle)
 				return fmt.Errorf("could not unmarshal certificate to DER: %w", err)
 			}
 


### PR DESCRIPTION
This PR removes extraneous calls to `CertFreeCertificateContext` in `DeleteCertificate` within the `capi` package. According to the Windows [library documentation](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certdeletecertificatefromstore):

> The CertDeleteCertificateFromStore function always frees pCertContext by calling the [CertFreeCertificateContext](https://learn.microsoft.com/en-us/windows/desktop/api/wincrypt/nf-wincrypt-certfreecertificatecontext) function, even if an error is encountered. Freeing the [context](https://learn.microsoft.com/en-us/windows/desktop/SecGloss/c-gly) reduces the context's [reference count](https://learn.microsoft.com/en-us/windows/desktop/SecGloss/r-gly) by one. If the reference count reaches zero, memory allocated for the certificate is freed.

Thus, calling `CertFreeCertificateContext` after `CertDeleteCertificateFromStore` is erroneous.

💔Thank you!
