### PR TITLE
Add support for using mackms keys with no tags

### DIFF
--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -95,6 +95,7 @@ var signatureAlgorithmMapping = map[apiv1.SignatureAlgorithm]algorithmAttributes
 // CreateKey methods can create keys with the following URIs:
 //   - mackms:label=my-name
 //   - mackms:label=my-name;tag=com.smallstep.crypto
+//   - mackms;label=my-name;tag=
 //   - mackms;label=my-name;se=true;bio=true
 //
 // GetPublicKey and CreateSigner accepts the above URIs as well as the following
@@ -107,7 +108,8 @@ var signatureAlgorithmMapping = map[apiv1.SignatureAlgorithm]algorithmAttributes
 //     represents the key name. You will be able to see the keys in the Keychain,
 //     looking for the value.
 //   - "tag" corresponds with kSecAttrApplicationTag. It defaults to
-//     com.smallstep.crypto.
+//     com.smallstep.crypto. If tag is an empty string ("tag="), the attribute
+//     will not be set.
 //   - "se" is a boolean. If set to true, it will store the key in the
 //     Secure Enclave. This option requires the application to be code-signed
 //     with the appropriate entitlements.

--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -189,12 +189,6 @@ func (k *MacKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespons
 	}
 
 	// Define key attributes
-	cfTag, err := cf.NewData([]byte(u.tag))
-	if err != nil {
-		return nil, fmt.Errorf("mackms CreateKey failed: %w", err)
-	}
-	defer cfTag.Release()
-
 	cfLabel, err := cf.NewString(u.label)
 	if err != nil {
 		return nil, fmt.Errorf("mackms CreateKey failed: %w", err)
@@ -202,8 +196,15 @@ func (k *MacKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespons
 	defer cfLabel.Release()
 
 	keyAttributesDict := cf.Dictionary{
-		security.KSecAttrApplicationTag: cfTag,
-		security.KSecAttrIsPermanent:    cf.True,
+		security.KSecAttrIsPermanent: cf.True,
+	}
+	if u.tag != "" {
+		cfTag, err := cf.NewData([]byte(u.tag))
+		if err != nil {
+			return nil, fmt.Errorf("mackms CreateKey failed: %w", err)
+		}
+		defer cfTag.Release()
+		keyAttributesDict[security.KSecAttrApplicationTag] = cfTag
 	}
 	if u.useSecureEnclave {
 		// After the first unlock, the data remains accessible until the next
@@ -491,12 +492,6 @@ func (*MacKMS) DeleteKey(req *apiv1.DeleteKeyRequest) error {
 		return fmt.Errorf("mackms DeleteKey failed: %w", err)
 	}
 
-	cfTag, err := cf.NewData([]byte(u.tag))
-	if err != nil {
-		return fmt.Errorf("mackms DeleteKey failed: %w", err)
-	}
-	defer cfTag.Release()
-
 	cfLabel, err := cf.NewString(u.label)
 	if err != nil {
 		return fmt.Errorf("mackms DeleteKey failed: %w", err)
@@ -505,10 +500,17 @@ func (*MacKMS) DeleteKey(req *apiv1.DeleteKeyRequest) error {
 
 	for _, keyClass := range []cf.TypeRef{security.KSecAttrKeyClassPublic, security.KSecAttrKeyClassPrivate} {
 		dict := cf.Dictionary{
-			security.KSecClass:              security.KSecClassKey,
-			security.KSecAttrApplicationTag: cfTag,
-			security.KSecAttrLabel:          cfLabel,
-			security.KSecAttrKeyClass:       keyClass,
+			security.KSecClass:        security.KSecClassKey,
+			security.KSecAttrLabel:    cfLabel,
+			security.KSecAttrKeyClass: keyClass,
+		}
+		if u.tag != "" {
+			cfTag, err := cf.NewData([]byte(u.tag))
+			if err != nil {
+				return fmt.Errorf("mackms DeleteKey failed: %w", err)
+			}
+			defer cfTag.Release()
+			dict[security.KSecAttrApplicationTag] = cfTag
 		}
 		// Extract logic to deleteItem to avoid defer on loops
 		if err := deleteItem(dict, u.hash); err != nil {
@@ -672,12 +674,6 @@ func deleteItem(dict cf.Dictionary, hash []byte) error {
 }
 
 func getPrivateKey(u *keyAttributes) (*security.SecKeyRef, error) {
-	cfTag, err := cf.NewData([]byte(u.tag))
-	if err != nil {
-		return nil, err
-	}
-	defer cfTag.Release()
-
 	cfLabel, err := cf.NewString(u.label)
 	if err != nil {
 		return nil, err
@@ -685,12 +681,19 @@ func getPrivateKey(u *keyAttributes) (*security.SecKeyRef, error) {
 	defer cfLabel.Release()
 
 	dict := cf.Dictionary{
-		security.KSecClass:              security.KSecClassKey,
-		security.KSecAttrApplicationTag: cfTag,
-		security.KSecAttrLabel:          cfLabel,
-		security.KSecAttrKeyClass:       security.KSecAttrKeyClassPrivate,
-		security.KSecReturnRef:          cf.True,
-		security.KSecMatchLimit:         security.KSecMatchLimitOne,
+		security.KSecClass:        security.KSecClassKey,
+		security.KSecAttrLabel:    cfLabel,
+		security.KSecAttrKeyClass: security.KSecAttrKeyClassPrivate,
+		security.KSecReturnRef:    cf.True,
+		security.KSecMatchLimit:   security.KSecMatchLimitOne,
+	}
+	if u.tag != "" {
+		cfTag, err := cf.NewData([]byte(u.tag))
+		if err != nil {
+			return nil, err
+		}
+		defer cfTag.Release()
+		dict[security.KSecAttrApplicationTag] = cfTag
 	}
 	if len(u.hash) > 0 {
 		d, err := cf.NewData(u.hash)
@@ -1013,7 +1016,7 @@ func parseURI(rawuri string) (*keyAttributes, error) {
 		return nil, fmt.Errorf("error parsing %q: label is required", rawuri)
 	}
 	tag := u.Get("tag")
-	if tag == "" {
+	if tag == "" && !u.Has("tag") {
 		tag = DefaultTag
 	}
 	return &keyAttributes{
@@ -1100,7 +1103,7 @@ func parseSearchURI(rawuri string) (*keySearchAttributes, error) {
 	// mackms:label=my-key;tag=my-tag;hash=010a...;se=true;bio=true
 	label := u.Get("label") // when searching, the label can be empty
 	tag := u.Get("tag")
-	if tag == "" {
+	if tag == "" && !u.Has("tag") {
 		tag = DefaultTag
 	}
 	return &keySearchAttributes{

--- a/kms/uri/uri.go
+++ b/kms/uri/uri.go
@@ -105,6 +105,11 @@ func (u *URI) String() string {
 	return u.URL.String()
 }
 
+// Has checks whether a given key is set.
+func (u *URI) Has(key string) bool {
+	return u.Values.Has(key) || u.URL.Query().Has(key)
+}
+
 // Get returns the first value in the uri with the given key, it will return
 // empty string if that field is not present.
 func (u *URI) Get(key string) string {

--- a/kms/uri/uri_test.go
+++ b/kms/uri/uri_test.go
@@ -153,6 +153,42 @@ func TestParseWithScheme(t *testing.T) {
 	}
 }
 
+func TestURI_Has(t *testing.T) {
+	mustParse := func(s string) *URI {
+		u, err := Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name string
+		uri  *URI
+		args args
+		want bool
+	}{
+		{"ok", mustParse("yubikey:slot-id=9a"), args{"slot-id"}, true},
+		{"ok empty", mustParse("yubikey:slot-id="), args{"slot-id"}, true},
+		{"ok query", mustParse("yubikey:pin=123456?slot-id="), args{"slot-id"}, true},
+		{"ok empty no equal", mustParse("yubikey:slot-id"), args{"slot-id"}, true},
+		{"ok query no equal", mustParse("yubikey:pin=123456?slot-id"), args{"slot-id"}, true},
+		{"ok empty no equal other", mustParse("yubikey:slot-id;pin=123456"), args{"slot-id"}, true},
+		{"ok query no equal other", mustParse("yubikey:pin=123456?slot-id&pin=123456"), args{"slot-id"}, true},
+		{"fail", mustParse("yubikey:pin=123456"), args{"slot-id"}, false},
+		{"fail with query", mustParse("yubikey:pin=123456?slot=9a"), args{"slot-id"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.uri.Has(tt.args.key); got != tt.want {
+				t.Errorf("URI.Has() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestURI_Get(t *testing.T) {
 	mustParse := func(s string) *URI {
 		u, err := Parse(s)


### PR DESCRIPTION
### Description

This commit allows to create, get, sign, and other operations using keys without a tag.

By default, the default tag used by the mackms package is `com.smallstep.crypto`. If we want to create or get a key using the URI `mackms:label=test`, the `mackms` package will assume that the default tag is being used.

The default tag can be changed using the tag parameter in the URI, e.g., `mackms:label=test;tag=my-tag`. But if we want not to use a tag, we need to provide the tag parameter empty, e,g., `mackms:label=test;tag=`. 

Programs using the `mackms` package can also set the `mackms.DefaultTag` to any other value, if it is set to empty, the created keys will not have a tag.

Fixes #595
