### PR TITLE
Allow to retry with no tags when loading privatekeys

### DIFF
--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -65,10 +65,8 @@ type keyAttributes struct {
 // would return the tag empty if it was set using the default value.
 func (k *keyAttributes) retryAttributes() *keyAttributes {
 	if !k.retry {
-		fmt.Println("no retry")
 		return nil
 	}
-	fmt.Println("retry")
 	return &keyAttributes{
 		label: k.label,
 		hash:  k.hash,

--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -52,10 +52,28 @@ type keyAttributes struct {
 	label            string
 	tag              string
 	hash             []byte
+	retry            bool
 	useSecureEnclave bool
 	useBiometrics    bool
 	sigAlgorithm     apiv1.SignatureAlgorithm
 	keySize          int
+}
+
+// retryAttributes returns the original URI attributes used to get a private
+// key, but only if they are different that the ones set. It will return nil, if
+// they are the same. The only attribute that can change is the tag. This method
+// would return the tag empty if it was set using the default value.
+func (k *keyAttributes) retryAttributes() *keyAttributes {
+	if !k.retry {
+		fmt.Println("no retry")
+		return nil
+	}
+	fmt.Println("retry")
+	return &keyAttributes{
+		label: k.label,
+		hash:  k.hash,
+		retry: false,
+	}
 }
 
 type keySearchAttributes struct {
@@ -715,6 +733,12 @@ func getPrivateKey(u *keyAttributes) (*security.SecKeyRef, error) {
 
 	var key cf.TypeRef
 	if err := security.SecItemCopyMatching(query, &key); err != nil {
+		// If not found retry without the tag if it wasn't set.
+		if errors.Is(err, security.ErrNotFound) {
+			if ru := u.retryAttributes(); ru != nil {
+				return getPrivateKey(ru)
+			}
+		}
 		return nil, fmt.Errorf("macOS SecItemCopyMatching failed: %w", err)
 	}
 	return security.NewSecKeyRef(key), nil
@@ -990,6 +1014,7 @@ func parseURI(rawuri string) (*keyAttributes, error) {
 		return &keyAttributes{
 			label: rawuri,
 			tag:   DefaultTag,
+			retry: true,
 		}, nil
 	}
 
@@ -1006,6 +1031,7 @@ func parseURI(rawuri string) (*keyAttributes, error) {
 				return &keyAttributes{
 					label: k,
 					tag:   DefaultTag,
+					retry: true,
 				}, nil
 			}
 		}
@@ -1025,6 +1051,7 @@ func parseURI(rawuri string) (*keyAttributes, error) {
 		label:            label,
 		tag:              tag,
 		hash:             u.GetEncoded("hash"),
+		retry:            !u.Has("tag"),
 		useSecureEnclave: u.GetBool("se"),
 		useBiometrics:    u.GetBool("bio"),
 	}, nil


### PR DESCRIPTION
### Description

This function allows you to retry the load of a key without tags if the original URL didn't have one.

This is used only in GetPublicKey and CreateSigner. It is not used in SearchKeys as duplicate keys must be removed.

cc: @joshdrake 