### PR TITLE
Add signer with reconnect

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -288,7 +288,7 @@ func (s *reconnectSigner) reconnect() error {
 			return nil, err
 		}
 		s.Signer = signer
-		return nil, nil
+		return nil, nil //nolint:nilnil // there's nothing to return
 	})
 	return err
 }


### PR DESCRIPTION
### Description

This commit implements a PKCS#11 signer that can reconnect to the PKCS#11 module if a sign fails with some specific errors.

@hslatman @dopey do not merge unless necessary.