### PR TITLE
support for yubikey management key from a file

### DIFF
--- a/kms/uri/uri.go
+++ b/kms/uri/uri.go
@@ -194,10 +194,25 @@ func (u *URI) Pin() string {
 	return ""
 }
 
+// Read returns the raw content of the file in the given attribute key. This
+// method will return nil if the key is missing.
+func (u *URI) Read(key string) ([]byte, error) {
+	path := u.Get(key)
+	if path == "" {
+		return nil, nil
+	}
+	return readFile(path)
+}
+
 func readFile(path string) ([]byte, error) {
 	u, err := url.Parse(path)
-	if err == nil && (u.Scheme == "" || u.Scheme == "file") && u.Path != "" {
-		path = u.Path
+	if err == nil && (u.Scheme == "" || u.Scheme == "file") {
+		switch {
+		case u.Path != "":
+			path = u.Path
+		case u.Opaque != "":
+			path = u.Opaque
+		}
 	}
 	b, err := os.ReadFile(path)
 	if err != nil {

--- a/kms/uri/uri_test.go
+++ b/kms/uri/uri_test.go
@@ -379,14 +379,14 @@ func TestURI_Read(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "management.key")
 	require.NoError(t, os.WriteFile(path, expected, 0600))
-	pinURI := &url.URL{
+	managementKeyURI := &url.URL{
 		Scheme: "file",
 		Path:   path,
 	}
 	pathURI := &URI{
 		URL: &url.URL{Scheme: "yubikey"},
 		Values: url.Values{
-			"management-key-source": []string{pinURI.String()},
+			"management-key-source": []string{managementKeyURI.String()},
 		},
 	}
 


### PR DESCRIPTION
### Description

This commit adds the yubikey attribute management-key-source. This attribute is used to pass the yubikey management key from a file.

Fixes smallstep/step-kms-plugin#207
