### PR TITLE
Fix flaky behavior for tests using sprig's `dateInZone`

### DIFF
--- a/internal/templates/funcmap_test.go
+++ b/internal/templates/funcmap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.step.sm/crypto/jose"
 )
 
@@ -221,7 +222,7 @@ func TestTemplates(t *testing.T) {
 		{"toTime dateModify", args{`{{ .nbf | toTime | dateModify "1h" }}`}, now.Add(time.Hour).String(), assert.NoError, assert.Empty},
 		{"formatTime", args{`{{ .nbf | formatTime }}`}, now.Format(time.RFC3339), assert.NoError, assert.Empty},
 		{"formatTime float64", args{`{{ .float64 | formatTime }}`}, now.Format(time.RFC3339), assert.NoError, assert.Empty},
-		{"formatTime in sprig", args{`{{ dateInZone "2006-01-02T15:04:05Z07:00" .float64 "UTC" }}`}, now.UTC().Format(time.RFC3339), assert.NoError, assert.Empty},
+		{"formatTime in sprig", args{`{{ dateInZone "2006-01-02T15:04:05Z07:00" .nbf "UTC" }}`}, now.UTC().Format(time.RFC3339), assert.NoError, assert.Empty},
 		{"parseTime", args{`{{ .notBefore | parseTime }}`}, now.String(), assert.NoError, assert.Empty},
 		{"parseTime toJson", args{`{{ .notBefore | parseTime | toJson }}`}, strconv.Quote(now.Format(time.RFC3339)), assert.NoError, assert.Empty},
 		{"parseTime time.UnixDate", args{`{{ .notAfter | parseTime "time.UnixDate" }}`}, now.Add(time.Hour).String(), assert.NoError, assert.Empty},

--- a/x509util/certificate_test.go
+++ b/x509util/certificate_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.step.sm/crypto/pemutil"
 )
 
@@ -568,6 +569,7 @@ func TestNewCertificateFromX509(t *testing.T) {
 			TokenKey: map[string]interface{}{
 				"iss": "https://iss",
 				"sub": "sub",
+				"nbf": now.Unix(),
 			},
 			WebhooksKey: map[string]interface{}{
 				"Test": map[string]interface{}{


### PR DESCRIPTION
The `dateInZone` template function would instantiate a new time using `time.Now()` when a type was provided that it doesn't handle explicitly. This could occasionally result in a mismatch in the time being reported and compared against, usually being the time the test was started.

Also see https://github.com/Masterminds/sprig/blob/8cb06fe3c8b0f1163c26b0a558669da72ee14656/date.go#L25-L48

Fixes #677 