### PR TITLE
Use utf8 string for private key subject with non-printable characters

### DIFF
--- a/internal/utils/asn1.go
+++ b/internal/utils/asn1.go
@@ -1,0 +1,33 @@
+package utils
+
+// IsPrintableString reports whether the given s is a valid ASN.1 PrintableString.
+// If asterisk is allowAsterisk then '*' is also allowed, reflecting existing
+// practice. If ampersand is allowAmpersand then '&' is allowed as well.
+func IsPrintableString(s string, asterisk, ampersand bool) bool {
+	for _, b := range s {
+		valid := 'a' <= b && b <= 'z' ||
+			'A' <= b && b <= 'Z' ||
+			'0' <= b && b <= '9' ||
+			'\'' <= b && b <= ')' ||
+			'+' <= b && b <= '/' ||
+			b == ' ' ||
+			b == ':' ||
+			b == '=' ||
+			b == '?' ||
+			// This is technically not allowed in a PrintableString.
+			// However, x509 certificates with wildcard strings don't
+			// always use the correct string type so we permit it.
+			(asterisk && b == '*') ||
+			// This is not technically allowed either. However, not
+			// only is it relatively common, but there are also a
+			// handful of CA certificates that contain it. At least
+			// one of which will not expire until 2027.
+			(ampersand && b == '&')
+
+		if !valid {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/utils/asn1_test.go
+++ b/internal/utils/asn1_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrintableString(t *testing.T) {
+	type args struct {
+		s         string
+		asterisk  bool
+		ampersand bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"empty", args{"", false, false}, true},
+		{"a", args{"a", false, false}, true},
+		{"spaces and caps", args{"My Leaf", false, false}, true},
+		{"default allowed punctuation", args{`(Hi+,-./):=?`, false, false}, true},
+		{"asterisk not allowed", args{"*", false, false}, false},
+		{"ampersand not allowed", args{"&", false, false}, false},
+		{"asterisk allowed", args{"*", true, false}, true},
+		{"ampersand allowed", args{"&", false, true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPrintableString(tt.args.s, tt.args.asterisk, tt.args.ampersand))
+		})
+	}
+}

--- a/nssdb/keys.go
+++ b/nssdb/keys.go
@@ -241,7 +241,7 @@ func (db *NSSDB) AddPublicKey(ctx context.Context, pubKey *ecdsa.PublicKey, ckaI
 	return pubKeyID, nil
 }
 
-var printableRx = regexp.MustCompile(`^[a-zA-Z0-9 '()+,-.\\:=?]*$`)
+var printableRx = regexp.MustCompile(`^[a-zA-Z0-9 '()+,\-.\\:=?]*$`)
 
 func isPrintable(s string) bool {
 	return printableRx.MatchString(s)

--- a/nssdb/keys.go
+++ b/nssdb/keys.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"regexp"
 
+	"go.step.sm/crypto/x509util"
 	"golang.org/x/crypto/cryptobyte"
 )
 
@@ -147,7 +147,7 @@ func ecPrivKeyToObject(priv *ecdsa.PrivateKey, name string, id []byte, certCNs .
 	if len(certCNs) > 0 {
 		sub := privateKeySubject{}
 		for _, cn := range certCNs {
-			if isPrintable(cn) {
+			if x509util.IsPrintableString(cn, false, false) {
 				sub.List = append(sub.List, certCN{
 					OID:        asn1.ObjectIdentifier{2, 5, 4, 3},
 					CommonName: cn,
@@ -239,10 +239,4 @@ func (db *NSSDB) AddPublicKey(ctx context.Context, pubKey *ecdsa.PublicKey, ckaI
 	}
 
 	return pubKeyID, nil
-}
-
-var printableRx = regexp.MustCompile(`^[a-zA-Z0-9 '()+,\-.\\:=?]*$`)
-
-func isPrintable(s string) bool {
-	return printableRx.MatchString(s)
 }

--- a/nssdb/keys.go
+++ b/nssdb/keys.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"go.step.sm/crypto/x509util"
+	"go.step.sm/crypto/internal/utils"
 	"golang.org/x/crypto/cryptobyte"
 )
 
@@ -147,7 +147,7 @@ func ecPrivKeyToObject(priv *ecdsa.PrivateKey, name string, id []byte, certCNs .
 	if len(certCNs) > 0 {
 		sub := privateKeySubject{}
 		for _, cn := range certCNs {
-			if x509util.IsPrintableString(cn, false, false) {
+			if utils.IsPrintableString(cn, false, false) {
 				sub.List = append(sub.List, certCN{
 					OID:        asn1.ObjectIdentifier{2, 5, 4, 3},
 					CommonName: cn,

--- a/nssdb/keys_test.go
+++ b/nssdb/keys_test.go
@@ -161,21 +161,3 @@ func TestNSSDB_AddPublicKey(t *testing.T) {
 		})
 	}
 }
-
-func TestIsPrintable(t *testing.T) {
-	tests := map[string]bool{
-		"":                     true,
-		"a":                    true,
-		"My Leaf":              true,
-		`(Hi+,-.\):=?`:         true,
-		"andrew@smallstep.com": false,
-		"some&":                false,
-		"*":                    false,
-	}
-	for s, want := range tests {
-		t.Run(s, func(t *testing.T) {
-			got := isPrintable(s)
-			assert.Equal(t, want, got)
-		})
-	}
-}

--- a/x509util/certificate_request.go
+++ b/x509util/certificate_request.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
+	"go.step.sm/crypto/internal/utils"
 	"golang.org/x/crypto/cryptobyte"
 	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -176,7 +177,7 @@ func (c *CertificateRequest) addChallengePassword(asn1Data []byte) ([]byte, erro
 		child.AddASN1ObjectIdentifier(oidChallengePassword)
 		child.AddASN1(cryptobyte_asn1.SET, func(value *cryptobyte.Builder) {
 			switch {
-			case IsPrintableString(c.ChallengePassword, true, true):
+			case utils.IsPrintableString(c.ChallengePassword, true, true):
 				value.AddASN1(cryptobyte_asn1.PrintableString, func(s *cryptobyte.Builder) {
 					s.AddBytes([]byte(c.ChallengePassword))
 				})

--- a/x509util/certificate_request.go
+++ b/x509util/certificate_request.go
@@ -176,7 +176,7 @@ func (c *CertificateRequest) addChallengePassword(asn1Data []byte) ([]byte, erro
 		child.AddASN1ObjectIdentifier(oidChallengePassword)
 		child.AddASN1(cryptobyte_asn1.SET, func(value *cryptobyte.Builder) {
 			switch {
-			case isPrintableString(c.ChallengePassword, true, true):
+			case IsPrintableString(c.ChallengePassword, true, true):
 				value.AddASN1(cryptobyte_asn1.PrintableString, func(s *cryptobyte.Builder) {
 					s.AddBytes([]byte(c.ChallengePassword))
 				})

--- a/x509util/extensions.go
+++ b/x509util/extensions.go
@@ -559,7 +559,7 @@ func marshalValue(value, params string) ([]byte, error) {
 		}
 		return asn1.MarshalWithParams(value, p.Params)
 	case "printable":
-		if !isPrintableString(value, true, true) {
+		if !IsPrintableString(value, true, true) {
 			return nil, fmt.Errorf("invalid printable value")
 		}
 		return asn1.MarshalWithParams(value, p.Params)
@@ -581,7 +581,7 @@ func marshalValue(value, params string) ([]byte, error) {
 		}
 		return asn1.MarshalWithParams(b, p.Params)
 	default: // if it's an unknown type, default to printable
-		if !isPrintableString(value, true, true) {
+		if !IsPrintableString(value, true, true) {
 			return nil, fmt.Errorf("invalid printable value")
 		}
 		return asn1.MarshalWithParams(value, p.Params)

--- a/x509util/extensions.go
+++ b/x509util/extensions.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.step.sm/crypto/internal/utils"
 )
 
 func convertName(s string) string {
@@ -559,7 +560,7 @@ func marshalValue(value, params string) ([]byte, error) {
 		}
 		return asn1.MarshalWithParams(value, p.Params)
 	case "printable":
-		if !IsPrintableString(value, true, true) {
+		if !utils.IsPrintableString(value, true, true) {
 			return nil, fmt.Errorf("invalid printable value")
 		}
 		return asn1.MarshalWithParams(value, p.Params)
@@ -581,7 +582,7 @@ func marshalValue(value, params string) ([]byte, error) {
 		}
 		return asn1.MarshalWithParams(b, p.Params)
 	default: // if it's an unknown type, default to printable
-		if !IsPrintableString(value, true, true) {
+		if !utils.IsPrintableString(value, true, true) {
 			return nil, fmt.Errorf("invalid printable value")
 		}
 		return asn1.MarshalWithParams(value, p.Params)

--- a/x509util/utils.go
+++ b/x509util/utils.go
@@ -180,10 +180,10 @@ func isNumericString(s string) bool {
 	return true
 }
 
-// isPrintableString reports whether the given s is a valid ASN.1 PrintableString.
+// IsPrintableString reports whether the given s is a valid ASN.1 PrintableString.
 // If asterisk is allowAsterisk then '*' is also allowed, reflecting existing
 // practice. If ampersand is allowAmpersand then '&' is allowed as well.
-func isPrintableString(s string, asterisk, ampersand bool) bool {
+func IsPrintableString(s string, asterisk, ampersand bool) bool {
 	for _, b := range s {
 		valid := 'a' <= b && b <= 'z' ||
 			'A' <= b && b <= 'Z' ||

--- a/x509util/utils.go
+++ b/x509util/utils.go
@@ -179,35 +179,3 @@ func isNumericString(s string) bool {
 
 	return true
 }
-
-// IsPrintableString reports whether the given s is a valid ASN.1 PrintableString.
-// If asterisk is allowAsterisk then '*' is also allowed, reflecting existing
-// practice. If ampersand is allowAmpersand then '&' is allowed as well.
-func IsPrintableString(s string, asterisk, ampersand bool) bool {
-	for _, b := range s {
-		valid := 'a' <= b && b <= 'z' ||
-			'A' <= b && b <= 'Z' ||
-			'0' <= b && b <= '9' ||
-			'\'' <= b && b <= ')' ||
-			'+' <= b && b <= '/' ||
-			b == ' ' ||
-			b == ':' ||
-			b == '=' ||
-			b == '?' ||
-			// This is technically not allowed in a PrintableString.
-			// However, x509 certificates with wildcard strings don't
-			// always use the correct string type so we permit it.
-			(asterisk && b == '*') ||
-			// This is not technically allowed either. However, not
-			// only is it relatively common, but there are also a
-			// handful of CA certificates that contain it. At least
-			// one of which will not expire until 2027.
-			(ampersand && b == '&')
-
-		if !valid {
-			return false
-		}
-	}
-
-	return true
-}


### PR DESCRIPTION
When importing a private key into an NSS database with a certificate, the certificate common name is used as the value of the CKA_SUBJECT attribute on the key object. This fixes the serialization to work when the CN contains characters that aren't valid for the asn1 printable string type.

💔Thank you!
