### PR TITLE
Add support for tokens with no pins

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -121,6 +121,10 @@ func New(_ context.Context, opts apiv1.Options) (*PKCS11, error) {
 	if config.Pin == "" && opts.Pin != "" {
 		config.Pin = opts.Pin
 	}
+	// If no pin is set, assume that the token does not support login.
+	if config.Pin == "" {
+		config.LoginNotSupported = true
+	}
 
 	switch {
 	case config.TokenLabel == "" && config.TokenSerial == "" && config.SlotNumber == nil:

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -122,7 +122,7 @@ func New(_ context.Context, opts apiv1.Options) (*PKCS11, error) {
 		config.Pin = opts.Pin
 	}
 	// If no pin is set, assume that the token does not support login.
-	if config.Pin == "" {
+	if config.Pin == "" && !u.Has("pin-value") && !u.Has("pin-source") {
 		config.LoginNotSupported = true
 	}
 


### PR DESCRIPTION
### Description

This commit sets the option LoginNotSupported if no pin is set. Servers using the p11-kit server protocol might not have a pin.

@hslatman should we do that? Or add an extra option? 
We don't have any other way to set a pin, so doing this I think is ok for now.