### PR TITLE
Fix open files with a full path in softkms

### DIFF
--- a/kms/softkms/softkms.go
+++ b/kms/softkms/softkms.go
@@ -195,7 +195,12 @@ func filename(s string) string {
 		if f := u.Get("path"); f != "" {
 			return f
 		}
-		return u.Opaque
+		switch {
+		case u.Path != "":
+			return u.Path
+		default:
+			return u.Opaque
+		}
 	}
 	return s
 }


### PR DESCRIPTION
### Description
This commit fixes the opening of files in `softkms` when an URI and a full path are used. e.g., `softkms:/path/to/file.pem`
