### PR TITLE
Remove underscore from `bcrypt_pbkdf` package

### DIFF
--- a/internal/bcrypt_pbkdf/bcrypt_pbkdf.go
+++ b/internal/bcrypt_pbkdf/bcrypt_pbkdf.go
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package bcrypt_pbkdf implements password-based key derivation function based
+// Package bcryptpbkdf implements password-based key derivation function based
 // on bcrypt compatible with bcrypt_pbkdf(3) from OpenBSD.
-//
-//nolint:staticcheck // ignore underscore in package
-package bcrypt_pbkdf
+package bcryptpbkdf
 
 import (
 	"crypto/sha512"

--- a/internal/bcrypt_pbkdf/bcrypt_pbkdf_test.go
+++ b/internal/bcrypt_pbkdf/bcrypt_pbkdf_test.go
@@ -1,9 +1,7 @@
 // Copyright 2014 Dmitry Chestnykh. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
-//nolint:staticcheck // ignore underscore in package
-package bcrypt_pbkdf
+package bcryptpbkdf
 
 import (
 	"bytes"


### PR DESCRIPTION
CI was flaky, sometimes triggering on the underscore, and sometimes not. For example, this [merge commit](https://github.com/smallstep/crypto/actions/runs/16138378521/job/45539789357) failed, whereas the [PR itself](https://github.com/smallstep/crypto/pull/800) was green. Let's deal with it once and for all.