### PR TITLE
Fix conversion of raw ecdsa p-521 signature to asn encoded

### DIFF
--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -965,19 +965,17 @@ func (s *CAPISigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([
 			return nil, err
 		}
 
-		if len(signatureBytes) >= len(digest)*2 {
-			sigR := signatureBytes[:len(digest)]
-			sigS := signatureBytes[len(digest):]
+		half := len(signatureBytes) >> 1
+		sigR := signatureBytes[:half]
+		sigS := signatureBytes[half:]
 
-			var b cryptobyte.Builder
-			b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
-				b.AddASN1BigInt(new(big.Int).SetBytes(sigR))
-				b.AddASN1BigInt(new(big.Int).SetBytes(sigS))
-			})
-			return b.Bytes()
-		}
+		var b cryptobyte.Builder
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			b.AddASN1BigInt(new(big.Int).SetBytes(sigR))
+			b.AddASN1BigInt(new(big.Int).SetBytes(sigS))
+		})
+		return b.Bytes()
 
-		return nil, fmt.Errorf("signatureBytes not long enough to encode ASN signature")
 	case "RSA":
 		hf := opts.HashFunc()
 		hashAlg, ok := hashAlgorithms[hf]


### PR DESCRIPTION

#### Pain or issue this feature alleviates:
Signature verification fails on Windows with capi kms when signing with EC p-521 keys since r and s are supposed to be 66 bytes each.


#### Supporting links/other PRs/issues:

Fix https://github.com/smallstep/cli/issues/1453.

💔Thank you!
