### PR TITLE
Use protection level HSM if it's given in the URI

### DIFF
--- a/kms/azurekms/key_vault.go
+++ b/kms/azurekms/key_vault.go
@@ -300,10 +300,9 @@ func (k *KeyVault) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespo
 		return nil, err
 	}
 
-	// Override protection level to HSM only if it's not specified, and is given
-	// in the uri.
+	// Override protection level to HSM only if is given in the uri.
 	protectionLevel := req.ProtectionLevel
-	if protectionLevel == apiv1.UnspecifiedProtectionLevel && hsm {
+	if hsm {
 		protectionLevel = apiv1.HSM
 	}
 


### PR DESCRIPTION
This commit prioritizes the `hsm=true` flag in the URI to create a key in an Azure HSM Key Vault. Before this change, `step-kms-plugin` required the use of the flag `--protection-level HSM` to create a key in the HSM.

Fixes smallstep/step-kms-plugin#252
