### PR TITLE
Accept nonRepudiation when unmarshalling keyUsage

### DIFF
--- a/x509util/extensions.go
+++ b/x509util/extensions.go
@@ -40,6 +40,8 @@ const (
 	KeyUsageCRLSign           = "crlSign"
 	KeyUsageEncipherOnly      = "encipherOnly"
 	KeyUsageDecipherOnly      = "decipherOnly"
+
+	keyUsageNonRepudiation = "nonRepudiation" // old name for contentCommitment
 )
 
 // Names used for extended key usages.
@@ -727,7 +729,9 @@ func (k *KeyUsage) UnmarshalJSON(data []byte) error {
 		switch convertName(s) {
 		case convertName(KeyUsageDigitalSignature):
 			ku = x509.KeyUsageDigitalSignature
-		case convertName(KeyUsageContentCommitment):
+		// support legacy name for better user experience for users coming from
+		// OpenSSL
+		case convertName(KeyUsageContentCommitment), convertName(keyUsageNonRepudiation):
 			ku = x509.KeyUsageContentCommitment
 		case convertName(KeyUsageKeyEncipherment):
 			ku = x509.KeyUsageKeyEncipherment

--- a/x509util/extensions_test.go
+++ b/x509util/extensions_test.go
@@ -519,6 +519,7 @@ func TestKeyUsage_UnmarshalJSON(t *testing.T) {
 		// Normalized
 		{"DigitalSignature", args{[]byte(`"DigitalSignature"`)}, KeyUsage(x509.KeyUsageDigitalSignature), false},
 		{"ContentCommitment", args{[]byte(`"ContentCommitment"`)}, KeyUsage(x509.KeyUsageContentCommitment), false},
+		{"NonRepudiation", args{[]byte(`"NonRepudiation"`)}, KeyUsage(x509.KeyUsageContentCommitment), false},
 		{"KeyEncipherment", args{[]byte(`"KeyEncipherment"`)}, KeyUsage(x509.KeyUsageKeyEncipherment), false},
 		{"DataEncipherment", args{[]byte(`"DataEncipherment"`)}, KeyUsage(x509.KeyUsageDataEncipherment), false},
 		{"KeyAgreement", args{[]byte(`"KeyAgreement"`)}, KeyUsage(x509.KeyUsageKeyAgreement), false},
@@ -529,6 +530,7 @@ func TestKeyUsage_UnmarshalJSON(t *testing.T) {
 		// Snake case
 		{"digital_signature", args{[]byte(`"digital_signature"`)}, KeyUsage(x509.KeyUsageDigitalSignature), false},
 		{"content_commitment", args{[]byte(`"content_commitment"`)}, KeyUsage(x509.KeyUsageContentCommitment), false},
+		{"non_repudiation", args{[]byte(`"non_repudiation"`)}, KeyUsage(x509.KeyUsageContentCommitment), false},
 		{"key_encipherment", args{[]byte(`"key_encipherment"`)}, KeyUsage(x509.KeyUsageKeyEncipherment), false},
 		{"data_encipherment", args{[]byte(`"data_encipherment"`)}, KeyUsage(x509.KeyUsageDataEncipherment), false},
 		{"key_agreement", args{[]byte(`"key_agreement"`)}, KeyUsage(x509.KeyUsageKeyAgreement), false},


### PR DESCRIPTION
#### Name of feature:
Accepting `NonRepudiation` when unmarshalling `keyUsage`.

#### Pain or issue this feature alleviates:
Better user experience for users that are used to the old name (e.g., from OpenSSL, which still uses the old name exclusively).

#### Is there documentation on how to use this feature? If so, where?
I didn't add any, because I don't think this should be advertised — but it's nice when it works when somebody attempts it.

#### Supporting links/other PRs/issues:
smallstep/certificates#2348

#### Description
ITU-T X.509 (10/2019) section 9.2.2.3 [1] defines 'contentCommitment' as the current name for what had previously been called 'nonRepudiation', and deprecates the old name:

> It is not incorrect to refer to this keyUsage bit using the identifier
> nonRepudiation. However, the use of this identifier has been
> deprecated.

The old name is still widely used, though — for example, OpenSSL still supports nonRepudiation exclusively. It is therefore not surprising that users attempt to specify that and just get an error message in return. See for example 
Modify the JSON unmarshalling to accept the old name, and transparently convert it to the new one. Keep marshalling the same, since we want to be conservative in what we send, but liberal in what we accept.

[1]: https://www.itu.int/rec/T-REC-X.509-201910-I/en

Related: smallstep/certificates#2348