### PR TITLE
Fix usage of azure keyvault client-secret when specified in URI

### DIFF
--- a/kms/azurekms/key_vault.go
+++ b/kms/azurekms/key_vault.go
@@ -191,7 +191,7 @@ var createCredentials = func(_ context.Context, opts apiv1.Options) (azcore.Toke
 		//   - client-secret
 		//   - tenant-id
 		if clientID != "" && clientSecret != "" && tenantID != "" {
-			return azidentity.NewClientSecretCredential(tenantID, clientID, clientID, &azidentity.ClientSecretCredentialOptions{
+			return azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, &azidentity.ClientSecretCredentialOptions{
 				ClientOptions: clientOptions,
 			})
 		}


### PR DESCRIPTION
…part of the URI

#### Pain or issue this feature alleviates:

It's a very simple fix. The `clientID` argument was passed to the function instead of `clientSecret`. The fix makes the Azure Key Vault kms URI settings work as expected
