### PR TITLE
Skip empty SANs

### DIFF
--- a/x509util/certificate_test.go
+++ b/x509util/certificate_test.go
@@ -146,6 +146,8 @@ func TestNewCertificate(t *testing.T) {
 	customSANsData.Set(SANsKey, []SubjectAlternativeName{
 		{Type: PermanentIdentifierType, Value: "123456"},
 		{Type: "1.2.3.4", Value: "utf8:otherName"},
+		// An empty SAN won't be encoded
+		{Type: "auto", Value: ""},
 	})
 	badCustomSANsData := CreateTemplateData("commonName", nil)
 	badCustomSANsData.Set(SANsKey, []SubjectAlternativeName{
@@ -202,6 +204,7 @@ func TestNewCertificate(t *testing.T) {
 			SANs: []SubjectAlternativeName{
 				{Type: PermanentIdentifierType, Value: "123456"},
 				{Type: "1.2.3.4", Value: "utf8:otherName"},
+				{Type: "auto", Value: ""},
 			},
 			Extensions: []Extension{{
 				ID:       ObjectIdentifier{2, 5, 29, 17},
@@ -378,6 +381,7 @@ func TestNewCertificateTemplate(t *testing.T) {
 		(dict "type" "hardwareModuleName" "value" .Insecure.User.hmn)
 		(dict "type" "userPrincipalName" "value" .Token.upn)
 		(dict "type" "1.2.3.4" "value" (printf "int:%s" .Insecure.User.id))
+		(dict "type" "auto" "value" "")
 	) | toJson }},
 	"notBefore": "{{ .Token.nbf | formatTime }}",
 	"notAfter": {{ now | dateModify "24h" | toJson }},

--- a/x509util/utils.go
+++ b/x509util/utils.go
@@ -55,6 +55,9 @@ func SplitSANs(sans []string) (dnsNames []string, ips []net.IP, emails []string,
 	emails = []string{}
 	uris = []*url.URL{}
 	for _, san := range sans {
+		if san == "" {
+			continue
+		}
 		ip := net.ParseIP(san)
 		u, err := url.Parse(san)
 		switch {

--- a/x509util/utils_test.go
+++ b/x509util/utils_test.go
@@ -61,7 +61,7 @@ func TestSplitSANs(t *testing.T) {
 			{Scheme: "mailto", Opaque: "john@doe.com"},
 			{Scheme: "urn", Opaque: "uuid:ddfe62ba-7e99-4bc1-83b3-8f57fe3e9959"},
 		}},
-		{"mixed", args{[]string{
+		{"mixed", args{[]string{"",
 			"foo.internal", "https://ca.smallstep.com", "max@smallstep.com",
 			"urn:uuid:ddfe62ba-7e99-4bc1-83b3-8f57fe3e9959", "mariano@smallstep.com",
 			"1.1.1.1", "bar.internal", "https://google.com/index.html",


### PR DESCRIPTION
With this commit we will skip empty SANs when rendering a template and building a X509 certificate from it.

Go 1.25.2 will fails to parse a certificate if for example the DNS is an empty string.
