### PR TITLE
Add support for additional CAPI certificate context properties

### DIFF
--- a/internal/termutil/termutil.go
+++ b/internal/termutil/termutil.go
@@ -60,7 +60,6 @@ func withTerminal(f func(in, out *os.File) error) error {
 		return f(tty, tty)
 	}
 
-	//nolint:gosec // Fd() returns uintptr, conversion to int is safe for file descriptors
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		return f(os.Stdin, os.Stdin)
 	}

--- a/internal/termutil/termutil.go
+++ b/internal/termutil/termutil.go
@@ -73,7 +73,6 @@ func ReadPassword(prompt string) (s []byte, err error) {
 	err = withTerminal(func(in, out *os.File) error {
 		fmt.Fprintf(out, "%s ", prompt)
 		defer clearLine(out)
-		//nolint:gosec // Fd() returns uintptr, conversion to int is safe for file descriptors
 		s, err = term.ReadPassword(int(in.Fd()))
 		return err
 	})

--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -84,7 +84,7 @@ type CertificateDeleter interface {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
 type CleaningCertificateManager interface {
-	Cleanup(issuer, storeLocation, store string, subjectRaw []byte) error
+	Cleanup(req *CleanupCertificatesRequest) error
 }
 
 // NameValidator is an interface that KeyManager can implement to validate a

--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -76,6 +76,17 @@ type CertificateDeleter interface {
 	DeleteCertificate(req *DeleteCertificateRequest) error
 }
 
+// CleaningCertificateManager is an optional interface for KMS implementations
+// that support cleaning up expired certificates from a certificate store.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later
+// release.
+type CleaningCertificateManager interface {
+	Cleanup(issuer, storeLocation, store string, subjectRaw []byte) error
+}
+
 // NameValidator is an interface that KeyManager can implement to validate a
 // given name or URI.
 type NameValidator interface {

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -364,5 +364,5 @@ type CleanupCertificatesRequest struct {
 	Issuer        string
 	StoreLocation string
 	Store         string
-	SubjectRaw    []byte
+	RawSubject    []byte
 }

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -350,3 +350,19 @@ type DeleteKeyRequest struct {
 type DeleteCertificateRequest struct {
 	Name string
 }
+
+// CleanupCertificatesRequest is the parameter used in the Cleanup method of a
+// CleaningCertificateManager. It identifies a certificate-store scope (issuer,
+// store location, store name) and a subject for which expired certificates
+// should be removed.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later
+// release.
+type CleanupCertificatesRequest struct {
+	Issuer        string
+	StoreLocation string
+	Store         string
+	SubjectRaw    []byte
+}

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -433,11 +433,9 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		}
 	case len(u.keyID) > 0:
 		if handle, err = findCertificateBySubjectKeyID(st, u.keyID); err != nil {
-			return nil, err
-		}
-
-		if handle == nil && !canLookupByIssuer {
-			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
+			if !errors.Is(err, apiv1.NotFoundError{}) || !canLookupByIssuer {
+				return nil, err
+			}
 		}
 	case u.containerName != "":
 		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
@@ -453,11 +451,9 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 			return nil, fmt.Errorf("error generating SubjectKeyID: %w", err)
 		}
 		if handle, err = findCertificateBySubjectKeyID(st, keyID); err != nil {
-			return nil, err
-		}
-
-		if handle == nil && !canLookupByIssuer {
-			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
+			if !errors.Is(err, apiv1.NotFoundError{}) || !canLookupByIssuer {
+				return nil, err
+			}
 		}
 	}
 

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -437,7 +437,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 			0,
 			findCertID,
 			uintptr(unsafe.Pointer(&searchData)), nil)
-		if err != nil && !canLookupByIssuer() {
+		if err != nil && !canLookupByIssuer {
 			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
 		}
 
@@ -863,12 +863,12 @@ func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 		cryptFindCertificateKeyProvInfo(certContext)
 	}
 
-	if friendlyName := u.Get(FriendlyNameArg); friendlyName != "" {
-		cryptSetCertificateFriendlyName(certContext, friendlyName)
+	if u.friendlyName != "" {
+		cryptSetCertificateFriendlyName(certContext, u.friendlyName)
 	}
 
-	if description := u.Get(DescriptionArg); description != "" {
-		cryptSetCertificateDescription(certContext, description)
+	if u.description != "" {
+		cryptSetCertificateDescription(certContext, u.description)
 	}
 
 	st, err := windows.CertOpenStore(
@@ -906,6 +906,8 @@ func (k *CAPIKMS) StoreCertificateChain(req *apiv1.StoreCertificateChainRequest)
 			HashArg:                []string{fp},
 			StoreLocationArg:       []string{u.storeLocation},
 			StoreNameArg:           []string{u.storeName},
+			FriendlyNameArg:        []string{u.friendlyName},
+			DescriptionArg:         []string{u.description},
 			SkipFindCertificateKey: []string{strconv.FormatBool(u.skipFindCertificateKey)},
 		}).String(),
 		Certificate: leaf,

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -404,6 +404,10 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
 	}
 
+	// if issuer + any of the other fields in the list below is provided, then attempt a second certificate lookup when
+	// lookup by KeyID fails (not found). This fix an issue when looking up device certificates, as in that case the KeyID is
+	// derived from a randomly generate string each time agent runs, thus not being able to find certificates installed from
+	// a previous run.
 	canLookupByIssuer := u.issuerName != "" && (u.serialNumber != "" || u.subjectCN != "" || u.friendlyName != "" || u.description != "")
 	var handle *windows.CertContext
 
@@ -431,19 +435,6 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		if handle, err = findCertificateBySubjectKeyID(st, u.keyID); err != nil {
 			return nil, err
 		}
-	case u.issuerName != "" && (u.serialNumber != nil || u.subjectCN != ""):
-		handle, err = findCertificateInStore(st,
-			encodingX509ASN|encodingPKCS7,
-			0,
-			findCertID,
-			uintptr(unsafe.Pointer(&searchData)), nil)
-		if err != nil && !canLookupByIssuer {
-			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
-		}
-
-		if handle == nil && !canLookupByIssuer {
-			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
-		}
 	case u.containerName != "":
 		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
 			Name: uri.New(Scheme, url.Values{
@@ -468,63 +459,64 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		return handle, err
 	}
 
-	if canLookupByIssuer {
-		var prevCert *windows.CertContext
-		for {
-			handle, err = findCertificateInStore(st,
-				encodingX509ASN|encodingPKCS7,
-				0,
-				findIssuerStr,
-				uintptr(unsafe.Pointer(wide(u.issuerName))), prevCert)
-			if err != nil {
-				return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
-			}
-
-			if handle == nil {
-				return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%q not found", IssuerNameArg, u.issuerName)}
-			}
-
-			x509Cert, err := certContextToX509(handle)
-			if err != nil {
-				return nil, fmt.Errorf("could not unmarshal certificate to DER: %w", err)
-			}
-
-			switch {
-			case u.serialNumber != nil:
-				// TODO: Replace this search with a CERT_ID + CERT_ISSUER_SERIAL_NUMBER search instead
-				// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_id
-				// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_issuer_serial_number
-				if x509Cert.SerialNumber.Cmp(u.serialNumber) == 0 {
-					return handle, nil
-				}
-			case len(u.subjectCN) > 0:
-				if x509Cert.Subject.CommonName == u.subjectCN {
-					return handle, nil
-				}
-			case len(u.friendlyName) > 0:
-				val, err := cryptFindCertificateFriendlyName(handle)
-				if err != nil {
-					return nil, fmt.Errorf("cryptFindCertificateFriendlyName failed: %w", err)
-				}
-
-				if val == u.friendlyName {
-					return handle, nil
-				}
-			case len(u.description) > 0:
-				val, err := cryptFindCertificateDescription(handle)
-				if err != nil {
-					return nil, fmt.Errorf("cryptFindCertificateDescription failed: %w", err)
-				}
-
-				if val == u.description {
-					return handle, nil
-				}
-			}
-
-			prevCert = handle
-		}
-	} else {
+	if !canLookupByIssuer {
 		return nil, fmt.Errorf("%q, %q, or %q and one of %q or %q is required to find a certificate", HashArg, KeyIDArg, IssuerNameArg, SerialNumberArg, SubjectCNArg)
+	}
+
+	// lookup certificate by issuer + another field (serial, CN, friendlyName, description)
+	var prevCert *windows.CertContext
+	for {
+		handle, err = findCertificateInStore(st,
+			encodingX509ASN|encodingPKCS7,
+			0,
+			findIssuerStr,
+			uintptr(unsafe.Pointer(wide(u.issuerName))), prevCert)
+		if err != nil {
+			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
+		}
+
+		if handle == nil {
+			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%q not found", IssuerNameArg, u.issuerName)}
+		}
+
+		x509Cert, err := certContextToX509(handle)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal certificate to DER: %w", err)
+		}
+
+		switch {
+		case u.serialNumber != nil:
+			// TODO: Replace this search with a CERT_ID + CERT_ISSUER_SERIAL_NUMBER search instead
+			// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_id
+			// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_issuer_serial_number
+			if x509Cert.SerialNumber.Cmp(u.serialNumber) == 0 {
+				return handle, nil
+			}
+		case len(u.subjectCN) > 0:
+			if x509Cert.Subject.CommonName == u.subjectCN {
+				return handle, nil
+			}
+		case len(u.friendlyName) > 0:
+			val, err := cryptFindCertificateFriendlyName(handle)
+			if err != nil {
+				return nil, fmt.Errorf("cryptFindCertificateFriendlyName failed: %w", err)
+			}
+
+			if val == u.friendlyName {
+				return handle, nil
+			}
+		case len(u.description) > 0:
+			val, err := cryptFindCertificateDescription(handle)
+			if err != nil {
+				return nil, fmt.Errorf("cryptFindCertificateDescription failed: %w", err)
+			}
+
+			if val == u.description {
+				return handle, nil
+			}
+		}
+
+		prevCert = handle
 	}
 }
 

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -823,6 +823,74 @@ func (k *CAPIKMS) LoadCertificateChain(req *apiv1.LoadCertificateChainRequest) (
 	return chain, nil
 }
 
+// FindCertificatesByIssuer returns all certificates in the Windows certificate
+// store that were issued by the given issuer. The URI must contain the "issuer"
+// field; "store-location" and "store" are optional (defaulting to "user" and "My").
+// When subjectRaw is non-empty, only certificates whose raw DER-encoded Subject
+// matches are included.
+func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, subjectRaw []byte) ([]*x509.Certificate, error) {
+	u, err := parseURI(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if u.issuerName == "" {
+		return nil, fmt.Errorf("%q is required", IssuerNameArg)
+	}
+
+	var certStoreLocation uint32
+	switch u.storeLocation {
+	case UserStoreLocation:
+		certStoreLocation = certStoreCurrentUser
+	case MachineStoreLocation:
+		certStoreLocation = certStoreLocalMachine
+	default:
+		return nil, fmt.Errorf("invalid cert store location %q", u.storeLocation)
+	}
+
+	st, err := windows.CertOpenStore(
+		certStoreProvSystem,
+		0,
+		0,
+		certStoreLocation,
+		uintptr(unsafe.Pointer(wide(u.storeName))),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+	}
+
+	var (
+		certs    []*x509.Certificate
+		prevCert *windows.CertContext
+	)
+	for {
+		certHandle, err := findCertificateInStore(st,
+			encodingX509ASN|encodingPKCS7,
+			0,
+			findIssuerStr,
+			uintptr(unsafe.Pointer(wide(u.issuerName))), prevCert)
+		if err != nil {
+			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
+		}
+		if certHandle == nil {
+			// prevCert was freed by the last findCertificateInStore call per Windows API contract.
+			break
+		}
+
+		x509Cert, err := certContextToX509(certHandle)
+		if err != nil {
+			windows.CertFreeCertificateContext(certHandle)
+			return nil, fmt.Errorf("could not unmarshal certificate: %w", err)
+		}
+
+		if len(subjectRaw) == 0 || bytes.Equal(x509Cert.RawSubject, subjectRaw) {
+			certs = append(certs, x509Cert)
+		}
+		prevCert = certHandle // freed on next findCertificateInStore call
+	}
+
+	return certs, nil
+}
+
 func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 	u, err := parseURI(req.Name)
 	if err != nil {

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -435,6 +435,10 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		if handle, err = findCertificateBySubjectKeyID(st, u.keyID); err != nil {
 			return nil, err
 		}
+
+		if handle == nil && !canLookupByIssuer {
+			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
+		}
 	case u.containerName != "":
 		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
 			Name: uri.New(Scheme, url.Values{
@@ -451,8 +455,10 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		if handle, err = findCertificateBySubjectKeyID(st, keyID); err != nil {
 			return nil, err
 		}
-	default:
-		return nil, fmt.Errorf("%q, %q, or %q and one of %q or %q is required to find a certificate", HashArg, KeyIDArg, IssuerNameArg, SerialNumberArg, SubjectCNArg)
+
+		if handle == nil && !canLookupByIssuer {
+			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
+		}
 	}
 
 	if handle != nil {

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -436,11 +436,12 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 			0,
 			findCertID,
 			uintptr(unsafe.Pointer(&searchData)), nil)
-		if err != nil {
+		if err != nil && !canLookupByIssuer() {
 			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
 		}
-		if handle == nil {
-			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%x not found", KeyIDArg, u.keyID)}
+
+		if handle == nil && !canLookupByIssuer {
+			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%s not found", KeyIDArg, u.keyID)}
 		}
 	case u.containerName != "":
 		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
@@ -499,22 +500,22 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 				if x509Cert.Subject.CommonName == u.subjectCN {
 					return handle, nil
 				}
-			case len(friendlyName) > 0:
+			case len(u.friendlyName) > 0:
 				val, err := cryptFindCertificateFriendlyName(handle)
 				if err != nil {
 					return nil, fmt.Errorf("cryptFindCertificateFriendlyName failed: %w", err)
 				}
 
-				if val == friendlyName {
+				if val == u.friendlyName {
 					return handle, nil
 				}
-			case len(description) > 0:
+			case len(u.description) > 0:
 				val, err := cryptFindCertificateDescription(handle)
 				if err != nil {
 					return nil, fmt.Errorf("cryptFindCertificateDescription failed: %w", err)
 				}
 
-				if val == description {
+				if val == u.description {
 					return handle, nil
 				}
 			}

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -408,7 +408,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 	// lookup by KeyID fails (not found). This fix an issue when looking up device certificates, as in that case the KeyID is
 	// derived from a randomly generate string each time agent runs, thus not being able to find certificates installed from
 	// a previous run.
-	canLookupByIssuer := u.issuerName != "" && (u.serialNumber != "" || u.subjectCN != "" || u.friendlyName != "" || u.description != "")
+	canLookupByIssuer := u.issuerName != "" && (u.serialNumber != nil || u.subjectCN != "" || u.friendlyName != "" || u.description != "")
 	var handle *windows.CertContext
 
 	switch {

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -405,9 +405,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 	}
 
 	// if issuer + any of the other fields in the list below is provided, then attempt a second certificate lookup when
-	// lookup by KeyID fails (not found). This fix an issue when looking up device certificates, as in that case the KeyID is
-	// derived from a randomly generate string each time agent runs, thus not being able to find certificates installed from
-	// a previous run.
+	// lookup by KeyID fails (not found).
 	canLookupByIssuer := u.issuerName != "" && (u.serialNumber != nil || u.subjectCN != "" || u.friendlyName != "" || u.description != "")
 	var handle *windows.CertContext
 

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -44,6 +44,8 @@ const (
 	HashArg                      = "sha1"
 	StoreLocationArg             = "store-location" // 'machine', 'user', etc
 	StoreNameArg                 = "store"          // 'MY', 'CA', 'ROOT', etc
+	FriendlyNameArg              = "friendly-name"
+	DescriptionArg               = "description"
 	IntermediateStoreLocationArg = "intermediate-store-location"
 	IntermediateStoreNameArg     = "intermediate-store"
 	KeyIDArg                     = "key-id"
@@ -91,6 +93,8 @@ type uriAttributes struct {
 	subjectCN                 string
 	serialNumber              *big.Int
 	issuerName                string
+	friendlyName              string
+	description               string
 	keySpec                   string
 	skipFindCertificateKey    bool
 	pin                       string
@@ -132,6 +136,8 @@ func parseURI(rawuri string) (*uriAttributes, error) {
 		subjectCN:                 u.Get(SubjectCNArg),
 		serialNumber:              serialNumber,
 		issuerName:                u.Get(IssuerNameArg),
+		friendlyName:              u.Get(FriendlyNameArg),
+		description:               u.Get(DescriptionArg),
 		keySpec:                   u.Get(KeySpec),
 		skipFindCertificateKey:    u.GetBool(SkipFindCertificateKey),
 		pin:                       u.Pin(),
@@ -397,6 +403,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
 	}
 
+	canLookupByIssuer := issuerName != "" && (serialNumber != "" || subjectCN != "" || friendlyName != "" || description != "")
 	var handle *windows.CertContext
 
 	switch {
@@ -424,6 +431,42 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 			return nil, err
 		}
 	case u.issuerName != "" && (u.serialNumber != nil || u.subjectCN != ""):
+		handle, err = findCertificateInStore(st,
+			encodingX509ASN|encodingPKCS7,
+			0,
+			findCertID,
+			uintptr(unsafe.Pointer(&searchData)), nil)
+		if err != nil {
+			return nil, fmt.Errorf("findCertificateInStore failed: %w", err)
+		}
+		if handle == nil {
+			return nil, apiv1.NotFoundError{Message: fmt.Sprintf("certificate with %s=%x not found", KeyIDArg, u.keyID)}
+		}
+	case u.containerName != "":
+		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
+			Name: uri.New(Scheme, url.Values{
+				ContainerNameArg: []string{u.containerName},
+			}).String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		keyID, err := x509util.GenerateSubjectKeyID(key)
+		if err != nil {
+			return nil, fmt.Errorf("error generating SubjectKeyID: %w", err)
+		}
+		if handle, err = findCertificateBySubjectKeyID(st, keyID); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("%q, %q, or %q and one of %q or %q is required to find a certificate", HashArg, KeyIDArg, IssuerNameArg, SerialNumberArg, SubjectCNArg)
+	}
+
+	if handle != nil {
+		return handle, err
+	}
+
+	if canLookupByIssuer {
 		var prevCert *windows.CertContext
 		for {
 			handle, err = findCertificateInStore(st,
@@ -456,31 +499,31 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 				if x509Cert.Subject.CommonName == u.subjectCN {
 					return handle, nil
 				}
+			case len(friendlyName) > 0:
+				val, err := cryptFindCertificateFriendlyName(prevCert)
+				if err != nil {
+					return nil, fmt.Errorf("cryptFindCertificateFriendlyName failed: %w", err)
+				}
+
+				if val == friendlyName {
+					return handle, nil
+				}
+			case len(description) > 0:
+				val, err := cryptFindCertificateDescription(prevCert)
+				if err != nil {
+					return nil, fmt.Errorf("cryptFindCertificateDescription failed: %w", err)
+				}
+
+				if val == description {
+					return handle, nil
+				}
 			}
 
 			prevCert = handle
 		}
-	case u.containerName != "":
-		key, err := k.GetPublicKey(&apiv1.GetPublicKeyRequest{
-			Name: uri.New(Scheme, url.Values{
-				ContainerNameArg: []string{u.containerName},
-			}).String(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		keyID, err := x509util.GenerateSubjectKeyID(key)
-		if err != nil {
-			return nil, fmt.Errorf("error generating SubjectKeyID: %w", err)
-		}
-		if handle, err = findCertificateBySubjectKeyID(st, keyID); err != nil {
-			return nil, err
-		}
-	default:
+	} else {
 		return nil, fmt.Errorf("%q, %q, or %q and one of %q or %q is required to find a certificate", HashArg, KeyIDArg, IssuerNameArg, SerialNumberArg, SubjectCNArg)
 	}
-
-	return handle, err
 }
 
 // CreateSigner returns a crypto.Signer that will sign using the key passed in via the URI.

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -398,12 +398,13 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		0,
 		0,
 		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))))
+		uintptr(unsafe.Pointer(wide(u.storeName))),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
 	}
 
-	canLookupByIssuer := issuerName != "" && (serialNumber != "" || subjectCN != "" || friendlyName != "" || description != "")
+	canLookupByIssuer := u.issuerName != "" && (u.serialNumber != "" || u.subjectCN != "" || u.friendlyName != "" || u.description != "")
 	var handle *windows.CertContext
 
 	switch {

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -861,6 +861,14 @@ func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 		cryptFindCertificateKeyProvInfo(certContext)
 	}
 
+	if friendlyName := u.Get(FriendlyNameArg); friendlyName != "" {
+		cryptSetCertificateFriendlyName(certContext, friendlyName)
+	}
+
+	if description := u.Get(DescriptionArg); description != "" {
+		cryptSetCertificateDescription(certContext, description)
+	}
+
 	st, err := windows.CertOpenStore(
 		certStoreProvSystem,
 		0,

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -500,7 +500,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 					return handle, nil
 				}
 			case len(friendlyName) > 0:
-				val, err := cryptFindCertificateFriendlyName(prevCert)
+				val, err := cryptFindCertificateFriendlyName(handle)
 				if err != nil {
 					return nil, fmt.Errorf("cryptFindCertificateFriendlyName failed: %w", err)
 				}
@@ -509,7 +509,7 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 					return handle, nil
 				}
 			case len(description) > 0:
-				val, err := cryptFindCertificateDescription(prevCert)
+				val, err := cryptFindCertificateDescription(handle)
 				if err != nil {
 					return nil, fmt.Errorf("cryptFindCertificateDescription failed: %w", err)
 				}

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -824,9 +824,9 @@ func (k *CAPIKMS) LoadCertificateChain(req *apiv1.LoadCertificateChainRequest) (
 // FindCertificatesByIssuer returns all certificates in the Windows certificate
 // store that were issued by the given issuer. The URI must contain the "issuer"
 // field; "store-location" and "store" are optional (defaulting to "user" and "My").
-// When subjectRaw is non-empty, only certificates whose raw DER-encoded Subject
+// When rawSubject is non-empty, only certificates whose raw DER-encoded Subject
 // matches are included.
-func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, subjectRaw []byte) ([]*x509.Certificate, error) {
+func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, rawSubject []byte) ([]*x509.Certificate, error) {
 	u, err := parseURI(req.Name)
 	if err != nil {
 		return nil, err
@@ -880,7 +880,7 @@ func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, su
 			return nil, fmt.Errorf("could not unmarshal certificate: %w", err)
 		}
 
-		if len(subjectRaw) == 0 || bytes.Equal(x509Cert.RawSubject, subjectRaw) {
+		if len(rawSubject) == 0 || bytes.Equal(x509Cert.RawSubject, rawSubject) {
 			certs = append(certs, x509Cert)
 		}
 		prevCert = certHandle // freed on next findCertificateInStore call

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -637,36 +637,34 @@ func cryptFindCertificateKeyContainerName(certContext *windows.CertContext) (str
 	return "", nil
 }
 
+func certGetCertificateContextProperty(certContext *windows.CertContext, propID uint32, pvData *byte, pcbData *uint32) error {
+	r0, _, err := procCertGetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(propID),
+		uintptr(unsafe.Pointer(pvData)),
+		uintptr(unsafe.Pointer(pcbData)),
+	)
+	if r0 == 0 {
+		return err
+	}
+	return nil
+}
+
 func cryptFindCertificateFriendlyName(certContext *windows.CertContext) (string, error) {
 	var size uint32
 
-	r1, _, err := procCertGetCertificateContextProperty.Call(
-		uintptr(unsafe.Pointer(certContext)),
-		uintptr(CERT_FRIENDLY_NAME_PROP_ID),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&size)),
-	)
-	if !errors.Is(err, windows.Errno(0)) {
-		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	err := certGetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, nil, &size)
+	if err != nil {
+		return "", err
 	}
-	if r1 == 0 {
-		return "", fmt.Errorf("finding certificate friendly name failed: %v", errNoToStr(uint32(r1)))
+	if size == 0 {
+		return "", fmt.Errorf("certificate has no friendly name")
 	}
 
 	buf := make([]byte, size)
-	r2, _, err := procCertGetCertificateContextProperty.Call(
-		uintptr(unsafe.Pointer(certContext)),
-		uintptr(CERT_KEY_PROV_INFO_PROP_ID),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&buf[0])),
-	)
-
-	if !errors.Is(err, windows.Errno(0)) {
-		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
-	}
-
-	if r2 == 0 {
-		return "", fmt.Errorf("finding certificate friendly name failed: %v", errNoToStr(uint32(r2)))
+	err = certGetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, &buf[0], &size)
+	if err != nil {
+		return "", err
 	}
 
 	uc := bytes.ReplaceAll(buf, []byte{0x00}, []byte(""))
@@ -676,33 +674,18 @@ func cryptFindCertificateFriendlyName(certContext *windows.CertContext) (string,
 func cryptFindCertificateDescription(certContext *windows.CertContext) (string, error) {
 	var size uint32
 
-	r1, _, err := procCertGetCertificateContextProperty.Call(
-		uintptr(unsafe.Pointer(certContext)),
-		uintptr(CERT_DESCRIPTION_PROP_ID),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&size)),
-	)
-	if !errors.Is(err, windows.Errno(0)) {
-		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	err := certGetCertificateContextProperty(certContext, CERT_DESCRIPTION_PROP_ID, nil, &size)
+	if err != nil {
+		return "", err
 	}
-	if r1 == 0 {
-		return "", fmt.Errorf("finding certificate description failed: %v", errNoToStr(uint32(r1)))
+	if size == 0 {
+		return "", fmt.Errorf("certificate has no description")
 	}
 
 	buf := make([]byte, size)
-	r2, _, err := procCertGetCertificateContextProperty.Call(
-		uintptr(unsafe.Pointer(certContext)),
-		uintptr(CERT_KEY_PROV_INFO_PROP_ID),
-		uintptr(0),
-		uintptr(unsafe.Pointer(&buf[0])),
-	)
-
-	if !errors.Is(err, windows.Errno(0)) {
-		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
-	}
-
-	if r2 == 0 {
-		return "", fmt.Errorf("finding certificate description failed: %v", errNoToStr(uint32(r2)))
+	err = certGetCertificateContextProperty(certContext, CERT_DESCRIPTION_PROP_ID, &buf[0], &size)
+	if err != nil {
+		return "", err
 	}
 
 	uc := bytes.ReplaceAll(buf, []byte{0x00}, []byte(""))

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -157,6 +157,7 @@ var (
 	procCertFindCertificateInStore        = crypt32.MustFindProc("CertFindCertificateInStore")
 	procCryptFindCertificateKeyProvInfo   = crypt32.MustFindProc("CryptFindCertificateKeyProvInfo")
 	procCertGetCertificateContextProperty = crypt32.MustFindProc("CertGetCertificateContextProperty")
+	procCertSetCertificateContextProperty = crypt32.MustFindProc("CertSetCertificateContextProperty")
 	procCertStrToName                     = crypt32.MustFindProc("CertStrToNameW")
 )
 
@@ -635,6 +636,38 @@ func cryptFindCertificateKeyContainerName(certContext *windows.CertContext) (str
 	}
 
 	return "", nil
+}
+
+func certSetCertificateContextProperty(certContext *windows.CertContext, propID uint32, pvData uintptr) error {
+	r0, _, err := procCertSetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(propID),
+		0,
+		pvData,
+	)
+
+	if r0 == 0 {
+		return err
+	}
+	return nil
+}
+
+func cryptSetCertificateFriendlyName(certContext *windows.CertContext, val string) error {
+	data := CRYPTOAPI_BLOB{
+		len: uint32(len(val)+1) * 2,
+		data: uintptr(unsafe.Pointer(wide(val))),
+	}
+
+	return certSetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, uintptr(unsafe.Pointer(&data)))
+}
+
+func cryptSetCertificateDescription(certContext *windows.CertContext, val string) error {
+	data := CRYPTOAPI_BLOB{
+		len: uint32(len(val)+1) * 2,
+		data: uintptr(unsafe.Pointer(wide(val))),
+	}
+
+	return certSetCertificateContextProperty(certContext, CERT_DESCRIPTION_PROP_ID, uintptr(unsafe.Pointer(&data)))
 }
 
 func certGetCertificateContextProperty(certContext *windows.CertContext, propID uint32, pvData *byte, pcbData *uint32) error {

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -62,7 +62,7 @@ const (
 	compareShift            = 16                                              // CERT_COMPARE_SHIFT
 	compareSHA1Hash         = 1                                               // CERT_COMPARE_SHA1_HASH
 	compareCertID           = 16                                              // CERT_COMPARE_CERT_ID
-	compareProp             = 5                                              // CERT_COMPARE_CERT_ID
+	compareProp             = 5                                               // CERT_COMPARE_CERT_ID
 	findIssuerStr           = compareNameStrW<<compareShift | infoIssuerFlag  // CERT_FIND_ISSUER_STR_W
 	findIssuerName          = compareName<<compareShift | infoIssuerFlag      // CERT_FIND_ISSUER_NAME
 	findHash                = compareSHA1Hash << compareShift                 // CERT_FIND_HASH
@@ -655,10 +655,15 @@ func cryptFindCertificateFriendlyName(certContext *windows.CertContext) (string,
 
 	err := certGetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, nil, &size)
 	if err != nil {
+		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+			return "", nil
+		}
+
 		return "", err
 	}
+
 	if size == 0 {
-		return "", fmt.Errorf("certificate has no friendly name")
+		return "", nil
 	}
 
 	buf := make([]byte, size)
@@ -676,10 +681,14 @@ func cryptFindCertificateDescription(certContext *windows.CertContext) (string, 
 
 	err := certGetCertificateContextProperty(certContext, CERT_DESCRIPTION_PROP_ID, nil, &size)
 	if err != nil {
+		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+			return "", nil
+		}
+
 		return "", err
 	}
 	if size == 0 {
-		return "", fmt.Errorf("certificate has no description")
+		return "", nil
 	}
 
 	buf := make([]byte, size)

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -62,7 +62,7 @@ const (
 	compareShift            = 16                                              // CERT_COMPARE_SHIFT
 	compareSHA1Hash         = 1                                               // CERT_COMPARE_SHA1_HASH
 	compareCertID           = 16                                              // CERT_COMPARE_CERT_ID
-	compareProp             = 5                                               // CERT_COMPARE_CERT_ID
+	compareProp             = 5                                               // CERT_COMPARE_PROPERTY
 	findIssuerStr           = compareNameStrW<<compareShift | infoIssuerFlag  // CERT_FIND_ISSUER_STR_W
 	findIssuerName          = compareName<<compareShift | infoIssuerFlag      // CERT_FIND_ISSUER_NAME
 	findHash                = compareSHA1Hash << compareShift                 // CERT_FIND_HASH

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -62,9 +62,11 @@ const (
 	compareShift            = 16                                              // CERT_COMPARE_SHIFT
 	compareSHA1Hash         = 1                                               // CERT_COMPARE_SHA1_HASH
 	compareCertID           = 16                                              // CERT_COMPARE_CERT_ID
+	compareProp             = 5                                              // CERT_COMPARE_CERT_ID
 	findIssuerStr           = compareNameStrW<<compareShift | infoIssuerFlag  // CERT_FIND_ISSUER_STR_W
 	findIssuerName          = compareName<<compareShift | infoIssuerFlag      // CERT_FIND_ISSUER_NAME
 	findHash                = compareSHA1Hash << compareShift                 // CERT_FIND_HASH
+	findProperty            = compareProp << compareShift                     // CERT_FIND_PROPERTY
 	findCertID              = compareCertID << compareShift                   // CERT_FIND_CERT_ID
 
 	signatureKeyUsage = 0x80       // CERT_DIGITAL_SIGNATURE_KEY_USAGE
@@ -84,6 +86,8 @@ const (
 	CERT_ID_SHA1_HASH            = uint32(3)
 
 	CERT_KEY_PROV_INFO_PROP_ID = uint32(2)
+	CERT_FRIENDLY_NAME_PROP_ID = uint32(11)
+	CERT_DESCRIPTION_PROP_ID   = uint32(13)
 
 	CERT_NAME_STR_COMMA_FLAG = uint32(0x04000000)
 	CERT_SIMPLE_NAME_STR     = uint32(1)
@@ -631,6 +635,78 @@ func cryptFindCertificateKeyContainerName(certContext *windows.CertContext) (str
 	}
 
 	return "", nil
+}
+
+func cryptFindCertificateFriendlyName(certContext *windows.CertContext) (string, error) {
+	var size uint32
+
+	r1, _, err := procCertGetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(CERT_FRIENDLY_NAME_PROP_ID),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&size)),
+	)
+	if !errors.Is(err, windows.Errno(0)) {
+		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	}
+	if r1 == 0 {
+		return "", fmt.Errorf("finding certificate friendly name failed: %v", errNoToStr(uint32(r1)))
+	}
+
+	buf := make([]byte, size)
+	r2, _, err := procCertGetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(CERT_KEY_PROV_INFO_PROP_ID),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+
+	if !errors.Is(err, windows.Errno(0)) {
+		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	}
+
+	if r2 == 0 {
+		return "", fmt.Errorf("finding certificate friendly name failed: %v", errNoToStr(uint32(r2)))
+	}
+
+	uc := bytes.ReplaceAll(buf, []byte{0x00}, []byte(""))
+	return string(uc), nil
+}
+
+func cryptFindCertificateDescription(certContext *windows.CertContext) (string, error) {
+	var size uint32
+
+	r1, _, err := procCertGetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(CERT_DESCRIPTION_PROP_ID),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&size)),
+	)
+	if !errors.Is(err, windows.Errno(0)) {
+		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	}
+	if r1 == 0 {
+		return "", fmt.Errorf("finding certificate description failed: %v", errNoToStr(uint32(r1)))
+	}
+
+	buf := make([]byte, size)
+	r2, _, err := procCertGetCertificateContextProperty.Call(
+		uintptr(unsafe.Pointer(certContext)),
+		uintptr(CERT_KEY_PROV_INFO_PROP_ID),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+
+	if !errors.Is(err, windows.Errno(0)) {
+		return "", fmt.Errorf("CertGetCertificateContextProperty returned %w", err)
+	}
+
+	if r2 == 0 {
+		return "", fmt.Errorf("finding certificate description failed: %v", errNoToStr(uint32(r2)))
+	}
+
+	uc := bytes.ReplaceAll(buf, []byte{0x00}, []byte(""))
+	return string(uc), nil
 }
 
 func certStrToName(x500Str string) ([]byte, error) {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -870,6 +870,8 @@ func (k *TPMKMS) loadCertificateChainFromWindowsCertificateStore(req *apiv1.Load
 			"store":                       []string{store},
 			"intermediate-store-location": []string{intermediateCAStoreLocation},
 			"intermediate-store":          []string{intermediateCAStore},
+			"friendly-name":               []string{o.friendlyName},
+			"description":                 []string{o.description},
 		}).String(),
 	})
 }

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -967,6 +967,8 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 		Name: uri.New("capi", url.Values{
 			"store-location":              []string{location},
 			"store":                       []string{store},
+			"friendly-name":               []string{o.friendlyName},
+			"description":                 []string{o.description},
 			"skip-find-certificate-key":   []string{skipFindCertificateKey},
 			"intermediate-store-location": []string{intermediateCAStoreLocation},
 			"intermediate-store":          []string{intermediateCAStore},

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -953,6 +953,14 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 	if o.store != "" {
 		store = o.store
 	}
+
+	if o.issuer != "" && (o.description == "device-id" || o.description == "step-agent-id") {
+		// best-effort: log failure but do not block the store operation
+		if err := k.cleanupExpiredCertificatesFromWindowsCertificateStore(o.issuer, location, store, req.CertificateChain[0].RawSubject); err != nil {
+			_ = err // TODO: replace with structured logging once a logger is available in this context
+		}
+	}
+
 	skipFindCertificateKey := "false"
 	if o.skipFindCertificateKey {
 		skipFindCertificateKey = "true"
@@ -978,6 +986,51 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 		}).String(),
 		CertificateChain: req.CertificateChain,
 	})
+}
+
+func (k *TPMKMS) loadCertificatesByIssuerFromWindowsCertificateStore(issuer, storeLocation, store string, subjectRaw []byte) ([]*x509.Certificate, error) {
+	finder, ok := k.windowsCertificateManager.(issuerCertificateFinder)
+	if !ok {
+		return nil, fmt.Errorf("certificate manager does not support finding certificates by issuer")
+	}
+
+	return finder.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
+		Name: uri.New("capi", url.Values{
+			"issuer":         []string{issuer},
+			"store-location": []string{storeLocation},
+			"store":          []string{store},
+		}).String(),
+	}, subjectRaw)
+}
+
+func (k *TPMKMS) cleanupExpiredCertificatesFromWindowsCertificateStore(issuer, storeLocation, store string, subjectRaw []byte) error {
+	certs, err := k.loadCertificatesByIssuerFromWindowsCertificateStore(issuer, storeLocation, store, subjectRaw)
+	if err != nil {
+		return fmt.Errorf("failed loading certificates by issuer %q: %w", issuer, err)
+	}
+
+	dk, ok := k.windowsCertificateManager.(deletingCertificateManager)
+	if !ok {
+		return fmt.Errorf("certificate manager does not support deleting certificates")
+	}
+
+	now := time.Now()
+	for _, cert := range certs {
+		if cert.NotAfter.Before(now) {
+			deleteURI := uri.New("capi", url.Values{
+				"store-location": []string{storeLocation},
+				"store":          []string{store},
+				"issuer":         []string{issuer},
+				"serial":         []string{"0x" + cert.SerialNumber.Text(16)},
+			}).String()
+
+			if err := dk.DeleteCertificate(&apiv1.DeleteCertificateRequest{Name: deleteURI}); err != nil {
+				return fmt.Errorf("failed deleting expired certificate (serial %s): %w", cert.SerialNumber.Text(16), err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // DeleteCertificate deletes a certificate for the key identified by name from the
@@ -1542,6 +1595,10 @@ func generateWindowsSubjectKeyID(pub crypto.PublicKey) (string, error) {
 type deletingCertificateManager interface {
 	apiv1.CertificateManager
 	DeleteCertificate(req *apiv1.DeleteCertificateRequest) error
+}
+
+type issuerCertificateFinder interface {
+	FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, subjectRaw []byte) ([]*x509.Certificate, error)
 }
 
 type deletingCertificateChainManager interface {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -870,6 +870,7 @@ func (k *TPMKMS) loadCertificateChainFromWindowsCertificateStore(req *apiv1.Load
 			"store":                       []string{store},
 			"intermediate-store-location": []string{intermediateCAStoreLocation},
 			"intermediate-store":          []string{intermediateCAStore},
+			"issuer":                      []string{o.issuer},
 			"friendly-name":               []string{o.friendlyName},
 			"description":                 []string{o.description},
 		}).String(),
@@ -1548,9 +1549,11 @@ type deletingCertificateChainManager interface {
 	DeleteCertificate(req *apiv1.DeleteCertificateRequest) error
 }
 
-var _ apiv1.KeyManager = (*TPMKMS)(nil)
-var _ apiv1.Attester = (*TPMKMS)(nil)
-var _ apiv1.CertificateManager = (*TPMKMS)(nil)
-var _ apiv1.CertificateChainManager = (*TPMKMS)(nil)
-var _ deletingCertificateChainManager = (*TPMKMS)(nil)
-var _ apiv1.AttestationClient = (*attestationClient)(nil)
+var (
+	_ apiv1.KeyManager                = (*TPMKMS)(nil)
+	_ apiv1.Attester                  = (*TPMKMS)(nil)
+	_ apiv1.CertificateManager        = (*TPMKMS)(nil)
+	_ apiv1.CertificateChainManager   = (*TPMKMS)(nil)
+	_ deletingCertificateChainManager = (*TPMKMS)(nil)
+	_ apiv1.AttestationClient         = (*attestationClient)(nil)
+)

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -1005,7 +1005,7 @@ func (k *TPMKMS) Cleanup(req *apiv1.CleanupCertificatesRequest) error {
 			"store-location": []string{req.StoreLocation},
 			"store":          []string{req.Store},
 		}).String(),
-	}, req.SubjectRaw)
+	}, req.RawSubject)
 	if err != nil {
 		return fmt.Errorf("failed loading certificates by issuer %q: %w", req.Issuer, err)
 	}
@@ -1600,7 +1600,7 @@ type deletingCertificateManager interface {
 }
 
 type issuerCertificateFinder interface {
-	FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, subjectRaw []byte) ([]*x509.Certificate, error)
+	FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, rawSubject []byte) ([]*x509.Certificate, error)
 }
 
 type deletingCertificateChainManager interface {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -1011,6 +1011,7 @@ func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte)
 		return fmt.Errorf("certificate manager does not support deleting certificates")
 	}
 
+	var deleteErrors []error
 	now := time.Now()
 	for _, cert := range certs {
 		if cert.NotAfter.Before(now) {
@@ -1022,12 +1023,12 @@ func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte)
 			}).String()
 
 			if err := dk.DeleteCertificate(&apiv1.DeleteCertificateRequest{Name: deleteURI}); err != nil {
-				return fmt.Errorf("failed deleting expired certificate (serial %s): %w", cert.SerialNumber.Text(16), err)
+				deleteErrors = append(deleteErrors, fmt.Errorf("failed deleting expired certificate (serial %s): %w", cert.SerialNumber.Text(16), err))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(deleteErrors...)
 }
 
 // DeleteCertificate deletes a certificate for the key identified by name from the

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -954,13 +954,6 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 		store = o.store
 	}
 
-	if o.issuer != "" && (o.description == "device-id" || o.description == "step-agent-id") {
-		// best-effort: log failure but do not block the store operation
-		if err := k.cleanupExpiredCertificatesFromWindowsCertificateStore(o.issuer, location, store, req.CertificateChain[0].RawSubject); err != nil {
-			_ = err // TODO: replace with structured logging once a logger is available in this context
-		}
-	}
-
 	skipFindCertificateKey := "false"
 	if o.skipFindCertificateKey {
 		skipFindCertificateKey = "true"
@@ -988,23 +981,26 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 	})
 }
 
-func (k *TPMKMS) loadCertificatesByIssuerFromWindowsCertificateStore(issuer, storeLocation, store string, subjectRaw []byte) ([]*x509.Certificate, error) {
-	finder, ok := k.windowsCertificateManager.(issuerCertificateFinder)
-	if !ok {
-		return nil, fmt.Errorf("certificate manager does not support finding certificates by issuer")
+// Cleanup implements [apiv1.CleaningCertificateManager]. It finds all certificates
+// in the Windows certificate store issued to the given subject by the given issuer,
+// and deletes any that have already expired.
+func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte) error {
+	if !k.usesWindowsCertificateStore() {
+		return apiv1.NotImplementedError{}
 	}
 
-	return finder.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
+	finder, ok := k.windowsCertificateManager.(issuerCertificateFinder)
+	if !ok {
+		return fmt.Errorf("certificate manager does not support finding certificates by issuer")
+	}
+
+	certs, err := finder.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
 		Name: uri.New("capi", url.Values{
 			"issuer":         []string{issuer},
 			"store-location": []string{storeLocation},
 			"store":          []string{store},
 		}).String(),
 	}, subjectRaw)
-}
-
-func (k *TPMKMS) cleanupExpiredCertificatesFromWindowsCertificateStore(issuer, storeLocation, store string, subjectRaw []byte) error {
-	certs, err := k.loadCertificatesByIssuerFromWindowsCertificateStore(issuer, storeLocation, store, subjectRaw)
 	if err != nil {
 		return fmt.Errorf("failed loading certificates by issuer %q: %w", issuer, err)
 	}
@@ -1607,10 +1603,11 @@ type deletingCertificateChainManager interface {
 }
 
 var (
-	_ apiv1.KeyManager                = (*TPMKMS)(nil)
-	_ apiv1.Attester                  = (*TPMKMS)(nil)
-	_ apiv1.CertificateManager        = (*TPMKMS)(nil)
-	_ apiv1.CertificateChainManager   = (*TPMKMS)(nil)
-	_ deletingCertificateChainManager = (*TPMKMS)(nil)
-	_ apiv1.AttestationClient         = (*attestationClient)(nil)
+	_ apiv1.KeyManager                  = (*TPMKMS)(nil)
+	_ apiv1.Attester                    = (*TPMKMS)(nil)
+	_ apiv1.CertificateManager          = (*TPMKMS)(nil)
+	_ apiv1.CertificateChainManager     = (*TPMKMS)(nil)
+	_ apiv1.CleaningCertificateManager  = (*TPMKMS)(nil)
+	_ deletingCertificateChainManager   = (*TPMKMS)(nil)
+	_ apiv1.AttestationClient           = (*attestationClient)(nil)
 )

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -982,9 +982,13 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 }
 
 // Cleanup implements [apiv1.CleaningCertificateManager]. It finds all certificates
-// in the Windows certificate store issued to the given subject by the given issuer,
-// and deletes any that have already expired.
-func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte) error {
+// in the Windows certificate store issued to the subject in req by the issuer in
+// req, and deletes any that have already expired.
+func (k *TPMKMS) Cleanup(req *apiv1.CleanupCertificatesRequest) error {
+	if req == nil {
+		return errors.New("cleanupCertificatesRequest cannot be nil")
+	}
+
 	if !k.usesWindowsCertificateStore() {
 		// currently this API is a no-op on non Windows platforms.
 		return nil
@@ -997,13 +1001,13 @@ func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte)
 
 	certs, err := finder.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
 		Name: uri.New("capi", url.Values{
-			"issuer":         []string{issuer},
-			"store-location": []string{storeLocation},
-			"store":          []string{store},
+			"issuer":         []string{req.Issuer},
+			"store-location": []string{req.StoreLocation},
+			"store":          []string{req.Store},
 		}).String(),
-	}, subjectRaw)
+	}, req.SubjectRaw)
 	if err != nil {
-		return fmt.Errorf("failed loading certificates by issuer %q: %w", issuer, err)
+		return fmt.Errorf("failed loading certificates by issuer %q: %w", req.Issuer, err)
 	}
 
 	dk, ok := k.windowsCertificateManager.(deletingCertificateManager)
@@ -1016,9 +1020,9 @@ func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte)
 	for _, cert := range certs {
 		if cert.NotAfter.Before(now) {
 			deleteURI := uri.New("capi", url.Values{
-				"store-location": []string{storeLocation},
-				"store":          []string{store},
-				"issuer":         []string{issuer},
+				"store-location": []string{req.StoreLocation},
+				"store":          []string{req.Store},
+				"issuer":         []string{req.Issuer},
 				"serial":         []string{"0x" + cert.SerialNumber.Text(16)},
 			}).String()
 

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -986,7 +986,8 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 // and deletes any that have already expired.
 func (k *TPMKMS) Cleanup(issuer, storeLocation, store string, subjectRaw []byte) error {
 	if !k.usesWindowsCertificateStore() {
-		return apiv1.NotImplementedError{}
+		// currently this API is a no-op on non Windows platforms.
+		return nil
 	}
 
 	finder, ok := k.windowsCertificateManager.(issuerCertificateFinder)
@@ -1603,11 +1604,11 @@ type deletingCertificateChainManager interface {
 }
 
 var (
-	_ apiv1.KeyManager                  = (*TPMKMS)(nil)
-	_ apiv1.Attester                    = (*TPMKMS)(nil)
-	_ apiv1.CertificateManager          = (*TPMKMS)(nil)
-	_ apiv1.CertificateChainManager     = (*TPMKMS)(nil)
-	_ apiv1.CleaningCertificateManager  = (*TPMKMS)(nil)
-	_ deletingCertificateChainManager   = (*TPMKMS)(nil)
-	_ apiv1.AttestationClient           = (*attestationClient)(nil)
+	_ apiv1.KeyManager                 = (*TPMKMS)(nil)
+	_ apiv1.Attester                   = (*TPMKMS)(nil)
+	_ apiv1.CertificateManager         = (*TPMKMS)(nil)
+	_ apiv1.CertificateChainManager    = (*TPMKMS)(nil)
+	_ apiv1.CleaningCertificateManager = (*TPMKMS)(nil)
+	_ deletingCertificateChainManager  = (*TPMKMS)(nil)
+	_ apiv1.AttestationClient          = (*attestationClient)(nil)
 )

--- a/kms/tpmkms/uri.go
+++ b/kms/tpmkms/uri.go
@@ -59,8 +59,10 @@ func parseNameURI(nameURI string) (o objectProperties, err error) {
 			o.qualifyingData = qualifyingData
 		}
 
-		// store location, store options are used on Windows to override
+		// store location and store options are used on Windows to override
 		// which store(s) are used for storing and loading (intermediate) certificates
+		// friendly-name and description are used on Windows to populate additional certificate
+		// context properties to aid in retrieval
 		o.storeLocation = u.Get("store-location")
 		o.store = u.Get("store")
 		o.friendlyName = u.Get("friendly-name")

--- a/kms/tpmkms/uri.go
+++ b/kms/tpmkms/uri.go
@@ -18,6 +18,8 @@ type objectProperties struct {
 	path                      string
 	storeLocation             string
 	store                     string
+	friendlyName              string
+	description               string
 	intermediateStoreLocation string
 	intermediateStore         string
 	skipFindCertificateKey    bool
@@ -57,10 +59,12 @@ func parseNameURI(nameURI string) (o objectProperties, err error) {
 			o.qualifyingData = qualifyingData
 		}
 
-		// store location and store options are used on Windows to override
+		// store location, store options are used on Windows to override
 		// which store(s) are used for storing and loading (intermediate) certificates
 		o.storeLocation = u.Get("store-location")
 		o.store = u.Get("store")
+		o.friendlyName = u.Get("friendly-name")
+		o.description = u.Get("description")
 		o.intermediateStoreLocation = u.Get("intermediate-store-location")
 		o.intermediateStore = u.Get("intermediate-store")
 		o.skipFindCertificateKey = u.GetBool("skip-find-certificate-key")


### PR DESCRIPTION
This PR adds functionality to the `capi` KMS to support setting the "friendly name" and "description" certificate properties. The `tpmkms` passes these through as needed.

💔Thank you!
