### PR TITLE
Use 'AfterFirstUnlock' for access control of SE keys.

### DIFF
--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -261,7 +261,7 @@ func (k *MacKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespons
 			flags |= security.KSecAccessControlBiometryCurrentSet
 		}
 		access, err := security.SecAccessControlCreateWithFlags(
-			security.KSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+			security.KSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
 			flags,
 		)
 		if err != nil {


### PR DESCRIPTION
I think the original intent here actually _was_ to use `AfterFirstUnlock`, but regardless, this PR makes that the default. We should prioritize making this configurable to support other use cases.

💔Thank you!
