### PR TITLE
Add support for P-384 keys on the secure enclave

### DIFF
--- a/kms/mackms/mackms.go
+++ b/kms/mackms/mackms.go
@@ -218,7 +218,9 @@ func (k *MacKMS) CreateKey(req *apiv1.CreateKeyRequest) (*apiv1.CreateKeyRespons
 	if !ok {
 		return nil, fmt.Errorf("createKeyRequest 'signatureAlgorithm=%q' is not supported", req.SignatureAlgorithm)
 	}
-	if u.useSecureEnclave && req.SignatureAlgorithm != apiv1.UnspecifiedSignAlgorithm && req.SignatureAlgorithm != apiv1.ECDSAWithSHA256 {
+	if u.useSecureEnclave && req.SignatureAlgorithm != apiv1.UnspecifiedSignAlgorithm &&
+		req.SignatureAlgorithm != apiv1.ECDSAWithSHA256 &&
+		req.SignatureAlgorithm != apiv1.ECDSAWithSHA384 {
 		return nil, fmt.Errorf("createKeyRequest 'signatureAlgorithm=%q' is not supported on Secure Enclave", req.SignatureAlgorithm)
 	}
 


### PR DESCRIPTION
This commit enables the creation of NIST P-384 keys on the Secure Enaclave.

See last section of https://support.apple.com/guide/security/managed-device-attestation-security-sec8a37b4cb2/web
```
To create a hardware-bound key, the ACME configuration needs to use the ECSECPrimeRandom algorithm
with a key size of 256 or 384 bit. This specifies a key pair on the P-256 or P-384 curves as defined 
in NIST SP 800-186.
```