### PR TITLE
Rename ThalesIgnite/crypto11 to ThalesGroup/crypto11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.step.sm/crypto
 
-go 1.25.0
+go 1.25.1
 
 retract [v0.77.3, v0.77.7] // unintentional releases tagged from non-master branch
 
@@ -11,7 +11,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/kms v1.51.1
 	github.com/go-jose/go-jose/v3 v3.0.5
@@ -48,6 +47,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+	github.com/ThalesGroup/crypto11 v1.6.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
@@ -77,7 +77,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/miekg/pkcs11 v1.0.3 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/ThalesGroup/crypto11 v1.6.0 h1:Og9EMn44fBS4GNnGnH1aqHnF2wL6F7IU/RhpJajWX/4=
+github.com/ThalesGroup/crypto11 v1.6.0/go.mod h1:H6LRjN5R5SHxTrLqGNteisLDI0/IC6+SGx1pHtbwizE=
 github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -610,6 +612,8 @@ github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/kms/pkcs11/opensc_test.go
+++ b/kms/pkcs11/opensc_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 )
 
 var softHSM2Once sync.Once

--- a/kms/pkcs11/other_test.go
+++ b/kms/pkcs11/other_test.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 	"github.com/pkg/errors"
 )
 

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 	"github.com/pkg/errors"
 
 	"go.step.sm/crypto/kms/apiv1"

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/kms/pkcs11/softhsm2_test.go
+++ b/kms/pkcs11/softhsm2_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 )
 
 var softHSM2Once sync.Once

--- a/kms/pkcs11/yubihsm2_test.go
+++ b/kms/pkcs11/yubihsm2_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/ThalesIgnite/crypto11"
+	"github.com/ThalesGroup/crypto11"
 )
 
 var yubiHSM2Once sync.Once


### PR DESCRIPTION
#### Name of feature:
N/A

#### Pain or issue this feature alleviates:
Missing updates on the Thales crypto11 project as they have renamed / moved their repo to a new organization on github.

#### Why is this important to the project (if not answered above):
The old `ThalesIgnite/crypto11` repo have not received updates for quite some time.
The new `ThalesGroup/crypto11` repo receives steady updates from Thales.

#### Is there documentation on how to use this feature? If so, where?
N/A

#### In what environments or workflows is this feature supported?
N/A

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A

#### Supporting links/other PRs/issues:
https://github.com/sigstore/fulcio/issues/2329

💔Thank you!
