### PR TITLE
Forward Cleanup calls to the backend in platform KMS

### DIFF
--- a/kms/platform/kms.go
+++ b/kms/platform/kms.go
@@ -89,9 +89,11 @@ type extendedKeyManager interface {
 	apiv1.CertificateDeleter
 }
 
-var _ apiv1.KeyManager = (*KMS)(nil)
-var _ apiv1.CertificateManager = (*KMS)(nil)
-var _ apiv1.CertificateChainManager = (*KMS)(nil)
+var (
+	_ apiv1.KeyManager              = (*KMS)(nil)
+	_ apiv1.CertificateManager      = (*KMS)(nil)
+	_ apiv1.CertificateChainManager = (*KMS)(nil)
+)
 
 type KMS struct {
 	typ              apiv1.Type
@@ -287,6 +289,14 @@ func (k *KMS) SearchKeys(req *apiv1.SearchKeysRequest) (*apiv1.SearchKeysRespons
 	}
 
 	return nil, apiv1.NotImplementedError{}
+}
+
+func (k *KMS) Cleanup(req *apiv1.CleanupCertificatesRequest) error {
+	if km, ok := k.backend.(apiv1.CleaningCertificateManager); ok {
+		return km.Cleanup(req)
+	}
+
+	return apiv1.NotImplementedError{}
 }
 
 func (k *KMS) patchCreateKeyResponse(resp *apiv1.CreateKeyResponse) (*apiv1.CreateKeyResponse, error) {


### PR DESCRIPTION
Add a Cleanup method on the platform KMS that delegates to the wrapped backend when it implements apiv1.CleaningCertificateManager, and returns NotImplementedError otherwise. This lets callers invoke certificate cleanup through the platform KMS the same way other optional capabilities are exposed.

Also group the interface-assertion var declarations into a single block.
