### PR TITLE
Refactor the Cleanup method

### DIFF
--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -76,15 +76,15 @@ type CertificateDeleter interface {
 	DeleteCertificate(req *DeleteCertificateRequest) error
 }
 
-// CleaningCertificateManager is an optional interface for KMS implementations
-// that support cleaning up expired certificates from a certificate store.
+// CredentialsCleaner is an optional interface for KMS implementations that
+// support cleaning up expired certificates from a certificate store.
 //
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
-type CleaningCertificateManager interface {
-	Cleanup(req *CleanupCertificatesRequest) error
+type CredentialsCleaner interface {
+	CleanupCredentials(req *CleanupCredentialsRequest) error
 }
 
 // NameValidator is an interface that KeyManager can implement to validate a

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -351,16 +351,16 @@ type DeleteCertificateRequest struct {
 	Name string
 }
 
-// CleanupCertificatesRequest is the parameter used in the Cleanup method of a
-// CleaningCertificateManager. It identifies a certificate-store scope (issuer,
-// store location, store name) and a subject for which expired certificates
-// should be removed.
+// CleanupCredentialsRequest is the parameter used in the CleanupCredentials
+// method of a CredentialsCleaner. It identifies a certificate-store scope
+// (issuer, store location, store name) and a subject for which expired
+// certificates should be removed.
 //
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
-type CleanupCertificatesRequest struct {
+type CleanupCredentialsRequest struct {
 	Issuer        string
 	StoreLocation string
 	Store         string

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -20,9 +21,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
@@ -1138,6 +1138,41 @@ func (k *CAPIKMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
 	default:
 		return fmt.Errorf("%q, %q, or %q and %q is required to find a certificate", HashArg, KeyIDArg, IssuerNameArg, SerialNumberArg)
 	}
+}
+
+// CleanupCredentials implements [apiv1.CredentialsCleaner]. It finds all
+// certificates in the Windows certificate store issued to the subject in req by
+// the issuer in req, and deletes any that have already expired.
+func (k *CAPIKMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
+	certs, err := k.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
+		Name: uri.New("capi", url.Values{
+			"issuer":         []string{req.Issuer},
+			"store-location": []string{req.StoreLocation},
+			"store":          []string{req.Store},
+		}).String(),
+	}, req.RawSubject)
+	if err != nil {
+		return fmt.Errorf("failed loading certificates by issuer %q: %w", req.Issuer, err)
+	}
+
+	var deleteErrors []error
+	now := time.Now()
+	for _, cert := range certs {
+		if cert.NotAfter.Before(now) {
+			deleteURI := uri.New("capi", url.Values{
+				"store-location": []string{req.StoreLocation},
+				"store":          []string{req.Store},
+				"issuer":         []string{req.Issuer},
+				"serial":         []string{"0x" + cert.SerialNumber.Text(16)},
+			}).String()
+
+			if err := k.DeleteCertificate(&apiv1.DeleteCertificateRequest{Name: deleteURI}); err != nil {
+				deleteErrors = append(deleteErrors, fmt.Errorf("failed deleting expired certificate (serial %s): %w", cert.SerialNumber.Text(16), err))
+			}
+		}
+	}
+
+	return errors.Join(deleteErrors...)
 }
 
 func (k *CAPIKMS) getKeyFlags(u *uriAttributes) (uint32, error) {

--- a/kms/platform/kms.go
+++ b/kms/platform/kms.go
@@ -93,6 +93,8 @@ var (
 	_ apiv1.KeyManager              = (*KMS)(nil)
 	_ apiv1.CertificateManager      = (*KMS)(nil)
 	_ apiv1.CertificateChainManager = (*KMS)(nil)
+	_ apiv1.SearchableKeyManager    = (*KMS)(nil)
+	_ apiv1.CredentialsCleaner      = (*KMS)(nil)
 )
 
 type KMS struct {
@@ -291,9 +293,9 @@ func (k *KMS) SearchKeys(req *apiv1.SearchKeysRequest) (*apiv1.SearchKeysRespons
 	return nil, apiv1.NotImplementedError{}
 }
 
-func (k *KMS) Cleanup(req *apiv1.CleanupCertificatesRequest) error {
-	if km, ok := k.backend.(apiv1.CleaningCertificateManager); ok {
-		return km.Cleanup(req)
+func (k *KMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
+	if km, ok := k.backend.(apiv1.CredentialsCleaner); ok {
+		return km.CleanupCredentials(req)
 	}
 
 	return apiv1.NotImplementedError{}

--- a/kms/platform/kms_darwin_test.go
+++ b/kms/platform/kms_darwin_test.go
@@ -1,9 +1,12 @@
 package platform
 
 import (
+	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.step.sm/crypto/kms/apiv1"
 )
 
 func mustPlatformKMS(t *testing.T) *KMS {
@@ -65,6 +68,38 @@ func Test_transformFromMacKMS(t *testing.T) {
 			got, err := transformFromMacKMS(tt.rawuri)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKMS_CleanupCredentials_mackms(t *testing.T) {
+	platformKMS := mustPlatformKMS(t)
+	// Use an expired certificate
+	chain := mustCreatePlatformCertificate(t, platformKMS, withTemplateModifier(func(c *x509.Certificate) *x509.Certificate {
+		c.NotBefore = time.Now().Add(-time.Minute).Truncate(time.Second)
+		c.NotAfter = time.Now().Add(-time.Second).Truncate(time.Second)
+		return c
+	}))
+
+	type args struct {
+		req *apiv1.CleanupCredentialsRequest
+	}
+	tests := []struct {
+		name      string
+		kms       *KMS
+		args      args
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"not implemented", platformKMS, args{&apiv1.CleanupCredentialsRequest{
+			Issuer:     chain[0].Issuer.CommonName,
+			RawSubject: chain[0].RawSubject,
+		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
+			return assert.ErrorIs(tt, err, apiv1.NotImplementedError{})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.kms.CleanupCredentials(tt.args.req))
 		})
 	}
 }

--- a/kms/platform/kms_other_test.go
+++ b/kms/platform/kms_other_test.go
@@ -51,6 +51,9 @@ func TestKMS_CleanupCredentials_other(t *testing.T) {
 		{"not implemented", platformKMS, args{&apiv1.CleanupCredentialsRequest{
 			RawSubject: chain[0].RawSubject,
 		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
+			if platformKMS.Type() == apiv1.TPMKMS {
+				return assert.NoError(t, err)
+			}
 			return assert.ErrorIs(tt, err, apiv1.NotImplementedError{})
 		}},
 	}

--- a/kms/platform/kms_other_test.go
+++ b/kms/platform/kms_other_test.go
@@ -3,9 +3,12 @@
 package platform
 
 import (
+	"crypto/x509"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.step.sm/crypto/kms/apiv1"
 	"go.step.sm/crypto/kms/uri"
 	"go.step.sm/crypto/tpm/available"
@@ -25,4 +28,35 @@ func mustPlatformKMS(t *testing.T) *KMS {
 // this platform.
 func (k *KMS) SkipTests() bool {
 	return k.Type() == apiv1.DefaultKMS
+}
+
+func TestKMS_CleanupCredentials_other(t *testing.T) {
+	platformKMS := mustPlatformKMS(t)
+	// Use an expired certificate
+	chain := mustCreatePlatformCertificate(t, platformKMS, withTemplateModifier(func(c *x509.Certificate) *x509.Certificate {
+		c.NotBefore = time.Now().Add(-time.Minute).Truncate(time.Second)
+		c.NotAfter = time.Now().Add(-time.Second).Truncate(time.Second)
+		return c
+	}))
+
+	type args struct {
+		req *apiv1.CleanupCredentialsRequest
+	}
+	tests := []struct {
+		name      string
+		kms       *KMS
+		args      args
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"not implemented", platformKMS, args{&apiv1.CleanupCredentialsRequest{
+			RawSubject: chain[0].RawSubject,
+		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
+			return assert.ErrorIs(tt, err, apiv1.NotImplementedError{})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.kms.CleanupCredentials(tt.args.req))
+		})
+	}
 }

--- a/kms/platform/kms_test.go
+++ b/kms/platform/kms_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -101,8 +102,14 @@ func mustReadSigner(t *testing.T, path string) crypto.Signer {
 	return signer
 }
 
-func mustCertificate(t *testing.T, path string) []*x509.Certificate {
+func mustCertificate(t *testing.T, path string, opts ...createFuncOption) []*x509.Certificate {
 	t.Helper()
+
+	o := new(createOptions)
+	o.templateModifier = func(c *x509.Certificate) *x509.Certificate { return c }
+	for _, fn := range opts {
+		fn(o)
+	}
 
 	ca, err := minica.New()
 	require.NoError(t, err)
@@ -110,12 +117,12 @@ func mustCertificate(t *testing.T, path string) []*x509.Certificate {
 	signer, err := keyutil.GenerateDefaultSigner()
 	require.NoError(t, err)
 
-	cert, err := ca.Sign(&x509.Certificate{
+	cert, err := ca.Sign(o.templateModifier(&x509.Certificate{
 		KeyUsage:    x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		PublicKey:   signer.Public(),
 		DNSNames:    []string{"example.com"},
-	})
+	}))
 	require.NoError(t, err)
 
 	if path != "" {
@@ -186,6 +193,7 @@ type createOptions struct {
 	name                 string
 	noCleanup            bool
 	noCleanupCertificate bool
+	templateModifier     func(*x509.Certificate) *x509.Certificate
 }
 
 type createFuncOption func(*createOptions)
@@ -206,6 +214,12 @@ func withNoCleanup() createFuncOption {
 func withNoCleanupCertificate() createFuncOption {
 	return func(co *createOptions) {
 		co.noCleanupCertificate = true
+	}
+}
+
+func withTemplateModifier(fn func(*x509.Certificate) *x509.Certificate) createFuncOption {
+	return func(co *createOptions) {
+		co.templateModifier = fn
 	}
 }
 
@@ -242,6 +256,7 @@ func mustCreatePlatformCertificate(t *testing.T, km *KMS, opts ...createFuncOpti
 	t.Helper()
 
 	o := new(createOptions)
+	o.templateModifier = func(c *x509.Certificate) *x509.Certificate { return c }
 	o.name = platformCertName
 	for _, fn := range opts {
 		fn(o)
@@ -257,12 +272,12 @@ func mustCreatePlatformCertificate(t *testing.T, km *KMS, opts ...createFuncOpti
 	}
 
 	key := mustCreatePlatformKey(t, km, opts...)
-	cert, err := ca.Sign(&x509.Certificate{
+	cert, err := ca.Sign(o.templateModifier(&x509.Certificate{
 		KeyUsage:    x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		PublicKey:   key.PublicKey,
 		DNSNames:    []string{"example.com"},
-	})
+	}))
 	require.NoError(t, err)
 
 	require.NoError(t, km.StoreCertificateChain(&apiv1.StoreCertificateChainRequest{
@@ -1285,6 +1300,39 @@ func TestKMS_SearchKeys(t *testing.T) {
 			got, err := tt.kms.SearchKeys(tt.args.req)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKMS_CleanupCredentials(t *testing.T) {
+	dir := t.TempDir()
+	softKMS := mustKMS(t, "kms:backend=softkms")
+	// Create an expired certificate
+	chain := mustCertificate(t, filepath.Join(dir, "chain.crt"), withTemplateModifier(func(c *x509.Certificate) *x509.Certificate {
+		c.NotBefore = time.Now().Add(-time.Minute).Truncate(time.Second)
+		c.NotAfter = time.Now().Add(-time.Second).Truncate(time.Second)
+		return c
+	}))
+
+	type args struct {
+		req *apiv1.CleanupCredentialsRequest
+	}
+	tests := []struct {
+		name      string
+		kms       *KMS
+		args      args
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"not implemented", softKMS, args{&apiv1.CleanupCredentialsRequest{
+			Issuer:     chain[0].Issuer.CommonName,
+			RawSubject: chain[0].RawSubject,
+		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
+			return assert.ErrorIs(tt, err, apiv1.NotImplementedError{})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.kms.CleanupCredentials(tt.args.req))
 		})
 	}
 }

--- a/kms/platform/kms_windows_test.go
+++ b/kms/platform/kms_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -496,6 +497,48 @@ func TestKMS_SearchKeys_capi(t *testing.T) {
 			got, err := tt.kms.SearchKeys(tt.args.req)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKMS_CleanupCredentials_capi(t *testing.T) {
+	capiKMS := mustCAPIKMS(t)
+	// Use an expired certificate
+	chain := mustCreatePlatformCertificate(t, capiKMS,
+		withNoCleanupCertificate(),
+		withTemplateModifier(func(c *x509.Certificate) *x509.Certificate {
+			c.NotBefore = time.Now().Add(-time.Minute).Truncate(time.Second)
+			c.NotAfter = time.Now().Add(-time.Second).Truncate(time.Second)
+			return c
+		}))
+
+	_, err := capiKMS.LoadCertificate(&apiv1.LoadCertificateRequest{
+		Name: platformCertName,
+	})
+	require.NoError(t, err)
+
+	type args struct {
+		req *apiv1.CleanupCredentialsRequest
+	}
+	tests := []struct {
+		name      string
+		kms       *KMS
+		args      args
+		assertion assert.ErrorAssertionFunc
+	}{
+		{"ok", capiKMS, args{&apiv1.CleanupCredentialsRequest{
+			Issuer:     chain[0].Issuer.CommonName,
+			RawSubject: chain[0].RawSubject,
+		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
+			_, loadErr := capiKMS.LoadCertificate(&apiv1.LoadCertificateRequest{
+				Name: platformCertName,
+			})
+			return assert.NoError(t, err) && assert.Error(t, loadErr)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.kms.CleanupCredentials(tt.args.req))
 		})
 	}
 }

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -427,7 +427,7 @@ func NewWithTPM(ctx context.Context, t *tpm.TPM, opts ...Option) (*TPMKMS, error
 
 		cm, ok = km.(capiCertificateManager)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type %T; expected apiv1.CertificateManager", km)
+			return nil, fmt.Errorf("unexpected type %T; expected capiCertificateManager", km)
 		}
 	}
 

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -986,7 +986,7 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 // the issuer in req, and deletes any that have already expired.
 func (k *TPMKMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
 	if req == nil {
-		return errors.New("cleanupCertificatesRequest cannot be nil")
+		return errors.New("cleanupCredentialsRequest cannot be nil")
 	}
 
 	if k.usesWindowsCertificateStore() {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -227,7 +227,7 @@ func ParseOptions(u *uri.URI) []Option {
 // TPMKMS is a KMS implementation backed by a TPM.
 type TPMKMS struct {
 	tpm                       *tpm.TPM
-	windowsCertificateManager apiv1.CertificateChainManager
+	windowsCertificateManager capiCertificateManager
 	opts                      *options
 }
 
@@ -404,7 +404,7 @@ func NewWithTPM(ctx context.Context, t *tpm.TPM, opts ...Option) (*TPMKMS, error
 		}
 	}
 
-	var cm apiv1.CertificateChainManager
+	var cm capiCertificateManager
 
 	// TODO(hs): support a mode in which the TPM storage doesn't rely on JSON on Windows
 	// at all, but directly feeds into OS native storage? Some operations can be NOOPs, such
@@ -425,7 +425,7 @@ func NewWithTPM(ctx context.Context, t *tpm.TPM, opts ...Option) (*TPMKMS, error
 			return nil, fmt.Errorf("failed creating CAPIKMS instance: %w", err)
 		}
 
-		cm, ok = km.(apiv1.CertificateChainManager)
+		cm, ok = km.(capiCertificateManager)
 		if !ok {
 			return nil, fmt.Errorf("unexpected type %T; expected apiv1.CertificateManager", km)
 		}
@@ -981,58 +981,20 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 	})
 }
 
-// Cleanup implements [apiv1.CleaningCertificateManager]. It finds all certificates
-// in the Windows certificate store issued to the subject in req by the issuer in
-// req, and deletes any that have already expired.
-func (k *TPMKMS) Cleanup(req *apiv1.CleanupCertificatesRequest) error {
+// CleanupCredentials implements [apiv1.CredentialsCleaner]. It finds all
+// certificates in the Windows certificate store issued to the subject in req by
+// the issuer in req, and deletes any that have already expired.
+func (k *TPMKMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
 	if req == nil {
 		return errors.New("cleanupCertificatesRequest cannot be nil")
 	}
 
-	if !k.usesWindowsCertificateStore() {
-		// currently this API is a no-op on non Windows platforms.
-		return nil
+	if k.usesWindowsCertificateStore() {
+		return k.windowsCertificateManager.CleanupCredentials(req)
 	}
 
-	finder, ok := k.windowsCertificateManager.(issuerCertificateFinder)
-	if !ok {
-		return fmt.Errorf("certificate manager does not support finding certificates by issuer")
-	}
-
-	certs, err := finder.FindCertificatesByIssuer(&apiv1.LoadCertificateRequest{
-		Name: uri.New("capi", url.Values{
-			"issuer":         []string{req.Issuer},
-			"store-location": []string{req.StoreLocation},
-			"store":          []string{req.Store},
-		}).String(),
-	}, req.RawSubject)
-	if err != nil {
-		return fmt.Errorf("failed loading certificates by issuer %q: %w", req.Issuer, err)
-	}
-
-	dk, ok := k.windowsCertificateManager.(deletingCertificateManager)
-	if !ok {
-		return fmt.Errorf("certificate manager does not support deleting certificates")
-	}
-
-	var deleteErrors []error
-	now := time.Now()
-	for _, cert := range certs {
-		if cert.NotAfter.Before(now) {
-			deleteURI := uri.New("capi", url.Values{
-				"store-location": []string{req.StoreLocation},
-				"store":          []string{req.Store},
-				"issuer":         []string{req.Issuer},
-				"serial":         []string{"0x" + cert.SerialNumber.Text(16)},
-			}).String()
-
-			if err := dk.DeleteCertificate(&apiv1.DeleteCertificateRequest{Name: deleteURI}); err != nil {
-				deleteErrors = append(deleteErrors, fmt.Errorf("failed deleting expired certificate (serial %s): %w", cert.SerialNumber.Text(16), err))
-			}
-		}
-	}
-
-	return errors.Join(deleteErrors...)
+	// currently this API is a no-op on non Windows platforms.
+	return nil
 }
 
 // DeleteCertificate deletes a certificate for the key identified by name from the
@@ -1130,12 +1092,7 @@ func (k *TPMKMS) deleteCertificateFromWindowsCertificateStore(req *apiv1.DeleteC
 		return errors.New(`at least one of "serial", "key-id", "sha1" or "name" is expected to be set`)
 	}
 
-	dk, ok := k.windowsCertificateManager.(deletingCertificateManager)
-	if !ok {
-		return fmt.Errorf("expected Windows certificate manager to implement DeleteCertificate")
-	}
-
-	if err := dk.DeleteCertificate(&apiv1.DeleteCertificateRequest{
+	if err := k.windowsCertificateManager.DeleteCertificate(&apiv1.DeleteCertificateRequest{
 		Name: uri.New("capi", uv).String(),
 	}); err != nil {
 		return fmt.Errorf("failed deleting certificate using Windows platform cryptography provider: %w", err)
@@ -1594,26 +1551,18 @@ func generateWindowsSubjectKeyID(pub crypto.PublicKey) (string, error) {
 	return hex.EncodeToString(hash[:]), nil
 }
 
-type deletingCertificateManager interface {
-	apiv1.CertificateManager
-	DeleteCertificate(req *apiv1.DeleteCertificateRequest) error
-}
-
-type issuerCertificateFinder interface {
-	FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, rawSubject []byte) ([]*x509.Certificate, error)
-}
-
-type deletingCertificateChainManager interface {
+type capiCertificateManager interface {
 	apiv1.CertificateChainManager
-	DeleteCertificate(req *apiv1.DeleteCertificateRequest) error
+	apiv1.CertificateDeleter
+	apiv1.CredentialsCleaner
 }
 
 var (
-	_ apiv1.KeyManager                 = (*TPMKMS)(nil)
-	_ apiv1.Attester                   = (*TPMKMS)(nil)
-	_ apiv1.CertificateManager         = (*TPMKMS)(nil)
-	_ apiv1.CertificateChainManager    = (*TPMKMS)(nil)
-	_ apiv1.CleaningCertificateManager = (*TPMKMS)(nil)
-	_ deletingCertificateChainManager  = (*TPMKMS)(nil)
-	_ apiv1.AttestationClient          = (*attestationClient)(nil)
+	_ apiv1.KeyManager              = (*TPMKMS)(nil)
+	_ apiv1.Attester                = (*TPMKMS)(nil)
+	_ apiv1.CertificateManager      = (*TPMKMS)(nil)
+	_ apiv1.CertificateChainManager = (*TPMKMS)(nil)
+	_ apiv1.CredentialsCleaner      = (*TPMKMS)(nil)
+	_ apiv1.CertificateDeleter      = (*TPMKMS)(nil)
+	_ apiv1.AttestationClient       = (*attestationClient)(nil)
 )

--- a/kms/tpmkms/tpmkms_simulator_test.go
+++ b/kms/tpmkms/tpmkms_simulator_test.go
@@ -2397,7 +2397,7 @@ func TestTPMKMS_SearchKeys(t *testing.T) {
 
 	type fields struct {
 		tpm                       *tpm.TPM
-		windowsCertificateManager apiv1.CertificateChainManager
+		windowsCertificateManager capiCertificateManager
 		opts                      *options
 	}
 	type args struct {


### PR DESCRIPTION
This method refactors the cleanup method and renames it to CleanupCredentials, renaming also the interface to CredentialsCleaner. It also moves the capi-specific functionality to the capi KMS.