### PR TITLE
gh: aligned workflow permissions with smallstep/workflows#324

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
 
 jobs:
   ci:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/goCI.yml@main
     with:
       only-latest-golang: false

--- a/.github/workflows/code-scan-cron.yml
+++ b/.github/workflows/code-scan-cron.yml
@@ -4,4 +4,9 @@ on:
 
 jobs:
   code-scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/workflows/.github/workflows/code-scan.yml@main
+    secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dependabot-auto-merge:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,6 @@ on:
       - reopened
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
This PR amends the workflows configuration to be more inline with smallstep/workflows#324. Specifically, it grants `actions: read`, `contents: read`, and `security-events: write` to the `ci` job, which calls `goCI.yml` with `run-codeql: true`; without these scopes the CodeQL sub-job cannot upload its findings.

It additionally addresses the following:

1. Relaxes the `dependabot-auto-merge.yml` permissions, since the called workflow no longer needs `contents: write` or `pull-requests: write`.
2. Drops `pull-requests: write` from `triage.yml`, since the called workflow only labels via the issues API.
