### PR TITLE
Use correct CNG-key value for 'dwKeySpec' when setting key provider info

### DIFF
--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -952,7 +952,7 @@ func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 		if u.isMachineKeyset() {
 			flags |= CRYPT_MACHINE_KEYSET
 		}
-		if err := setCertificateKeyProvInfo(certContext, u.keyContainerName, u.providerName, flags, ncryptKeySpec); err != nil {
+		if err := setCertificateKeyProvInfo(certContext, u.keyContainerName, u.providerName, flags, LEGACY_KEY_SPEC_NONE); err != nil {
 			return fmt.Errorf("failed associating certificate with key %q: %w", u.keyContainerName, err)
 		}
 	case !u.skipFindCertificateKey:

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -620,8 +620,8 @@ func cryptFindCertificateKeyProvInfo(certContext *windows.CertContext, keysetFla
 //
 // containerName is the CNG key (container) name, provName the storage provider
 // (e.g. "Microsoft Platform Crypto Provider"), dwFlags carries keyset flags
-// such as CRYPT_MACHINE_KEYSET, and dwKeySpec is the key spec (CNG keys use
-// CERT_NCRYPT_KEY_SPEC).
+// such as CRYPT_MACHINE_KEYSET, and dwKeySpec is the key spec (non-legacy CNG keys use
+// LEGACY_KEY_SPEC_NONE).
 func setCertificateKeyProvInfo(certContext *windows.CertContext, containerName, provName string, dwFlags, dwKeySpec uint32) error {
 	container, err := windows.UTF16PtrFromString(containerName)
 	if err != nil {

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -70,7 +70,6 @@ const (
 	findCertID              = compareCertID << compareShift                   // CERT_FIND_CERT_ID
 
 	signatureKeyUsage = 0x80       // CERT_DIGITAL_SIGNATURE_KEY_USAGE
-	ncryptKeySpec     = 0xFFFFFFFF // CERT_NCRYPT_KEY_SPEC
 
 	BCRYPT_RSAPUBLIC_BLOB = "RSAPUBLICBLOB"
 	BCRYPT_ECCPUBLIC_BLOB = "ECCPUBLICBLOB"
@@ -107,8 +106,9 @@ const (
 	CERT_SIMPLE_NAME_STR     = uint32(1)
 	CERT_X500_NAME_STR       = uint32(3)
 
-	AT_KEYEXCHANGE = uint32(1)
-	AT_SIGNATURE   = uint32(2)
+	LEGACY_KEY_SPEC_NONE = uint32(0)
+	AT_KEYEXCHANGE       = uint32(1)
+	AT_SIGNATURE         = uint32(2)
 
 	// Legacy CryptoAPI flags
 	bCryptPadPKCS1 = uint32(2)


### PR DESCRIPTION
When the `dwProvType` member is `0` (which is the case for CNG keys), this value is passed as the `dwLegacyKeySpec` parameter to the `NCryptOpenKey` function. The correct `dwLegacyKeySpec` value for non-legacy CNG keys is `0`.

https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crypt_key_prov_info

💔Thank you!
