### PR TITLE
Make TPM dirstore cache size configurable

### DIFF
--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -190,36 +190,40 @@ func WithWindowsIntermediateStore(store, location string) Option {
 // ParseTPMOptions is a helper method that returns a slice of [tpm.NewTPMOption]
 // for the given URI.
 func ParseTPMOptions(u *uri.URI) []tpm.NewTPMOption {
-	var opts []tpm.NewTPMOption
-	if device := u.Get("device"); device != "" {
-		opts = append(opts, tpm.WithDeviceName(device))
-	}
-	if storageDirectory := u.Get("storage-directory"); storageDirectory != "" {
-		opts = append(opts, tpm.WithStore(storage.NewDirstore(storageDirectory, parseDirstoreOptions(u)...)))
-	}
-	return opts
+	return tpmOptionsForURI(u, "")
 }
 
-// newDirstore constructs the dirstore backing a [New] TPMKMS. It is a package
-// var so tests can observe the storage directory and options New resolves.
+// newDirstore constructs the dirstore backing the TPM. It is a package var so
+// tests can observe the storage directory and options it is built with.
 var newDirstore = storage.NewDirstore
 
-// resolveStorageDirectory returns the TPM storage directory and dirstore
-// options that [New] uses for the given options and parsed URI. The directory
-// precedence is: a storage-directory in the URI wins, otherwise
-// opts.StorageDirectory, otherwise the default "tpm". The dirstore options
-// (e.g. the cache size) come from the URI via parseDirstoreOptions.
-func resolveStorageDirectory(opts apiv1.Options, u *uri.URI) (string, []storage.DirstoreOption) {
-	directory := "tpm" // store TPM objects in a relative tpm directory by default.
-	if opts.StorageDirectory != "" {
-		directory = opts.StorageDirectory
-	}
+// tpmOptionsForURI returns the [tpm.NewTPMOption]s encoded in u — the device
+// name and a dirstore (with any storage-cache-size applied). It is the single
+// place that turns a URI into TPM options, shared by [ParseTPMOptions] and
+// [New].
+//
+// The store is built from the URI's storage-directory when present, otherwise
+// from defaultStorageDirectory; when both are empty no store option is added,
+// so the caller falls back to tpm.New's default store. The dirstore is created
+// through newDirstore so tests can observe it.
+func tpmOptionsForURI(u *uri.URI, defaultStorageDirectory string) []tpm.NewTPMOption {
+	var device, directory string
 	if u != nil {
-		if d := u.Get("storage-directory"); d != "" {
-			directory = d
-		}
+		device = u.Get("device")
+		directory = u.Get("storage-directory")
 	}
-	return directory, parseDirstoreOptions(u)
+	if directory == "" {
+		directory = defaultStorageDirectory
+	}
+
+	var opts []tpm.NewTPMOption
+	if device != "" {
+		opts = append(opts, tpm.WithDeviceName(device))
+	}
+	if directory != "" {
+		opts = append(opts, tpm.WithStore(newDirstore(directory, parseDirstoreOptions(u)...)))
+	}
+	return opts
 }
 
 // parseDirstoreOptions returns the [storage.DirstoreOption]s encoded in the
@@ -417,8 +421,6 @@ func New(ctx context.Context, opts apiv1.Options) (kms *TPMKMS, err error) {
 	var uriOptions []Option
 	var u *uri.URI
 
-	// Parse the URI up front so the default store below can honor any storage
-	// options it carries (e.g. storage-cache-size).
 	if opts.URI != "" {
 		if u, err = uri.ParseWithScheme(Scheme, opts.URI); err != nil {
 			return nil, fmt.Errorf("failed parsing %q as URI: %w", opts.URI, err)
@@ -426,17 +428,15 @@ func New(ctx context.Context, opts apiv1.Options) (kms *TPMKMS, err error) {
 		uriOptions = ParseOptions(u)
 	}
 
-	storageDirectory, dirstoreOptions := resolveStorageDirectory(opts, u)
-	tpmOpts := []tpm.NewTPMOption{
-		tpm.WithStore(newDirstore(storageDirectory, dirstoreOptions...)),
-	}
-	if u != nil {
-		if device := u.Get("device"); device != "" {
-			tpmOpts = append(tpmOpts, tpm.WithDeviceName(device))
-		}
+	// Store TPM objects in a relative "tpm" directory by default; a
+	// storage-directory in the URI takes precedence (handled in
+	// tpmOptionsForURI).
+	storageDirectory := "tpm"
+	if opts.StorageDirectory != "" {
+		storageDirectory = opts.StorageDirectory
 	}
 
-	t, err := tpm.New(tpmOpts...)
+	t, err := tpm.New(tpmOptionsForURI(u, storageDirectory)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating new TPM: %w", err)
 	}

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -200,6 +200,24 @@ func ParseTPMOptions(u *uri.URI) []tpm.NewTPMOption {
 	return opts
 }
 
+// resolveStorageDirectory returns the TPM storage directory and dirstore
+// options that [New] uses for the given options and parsed URI. The directory
+// precedence is: a storage-directory in the URI wins, otherwise
+// opts.StorageDirectory, otherwise the default "tpm". The dirstore options
+// (e.g. the cache size) come from the URI via parseDirstoreOptions.
+func resolveStorageDirectory(opts apiv1.Options, u *uri.URI) (string, []storage.DirstoreOption) {
+	directory := "tpm" // store TPM objects in a relative tpm directory by default.
+	if opts.StorageDirectory != "" {
+		directory = opts.StorageDirectory
+	}
+	if u != nil {
+		if d := u.Get("storage-directory"); d != "" {
+			directory = d
+		}
+	}
+	return directory, parseDirstoreOptions(u)
+}
+
 // parseDirstoreOptions returns the [storage.DirstoreOption]s encoded in the
 // URI. It currently supports storage-cache-size, the maximum size in bytes of
 // the dirstore's in-memory read cache; setting it to 0 (or any negative value)
@@ -404,18 +422,14 @@ func New(ctx context.Context, opts apiv1.Options) (kms *TPMKMS, err error) {
 		uriOptions = ParseOptions(u)
 	}
 
-	storageDirectory := "tpm" // store TPM objects in a relative tpm directory by default.
-	if opts.StorageDirectory != "" {
-		storageDirectory = opts.StorageDirectory
-	}
+	storageDirectory, dirstoreOptions := resolveStorageDirectory(opts, u)
 	tpmOpts := []tpm.NewTPMOption{
-		tpm.WithStore(storage.NewDirstore(storageDirectory, parseDirstoreOptions(u)...)),
+		tpm.WithStore(storage.NewDirstore(storageDirectory, dirstoreOptions...)),
 	}
 	if u != nil {
-		// When the URI carries its own storage-directory this appends a second
-		// WithStore that overrides the default above; ParseTPMOptions applies
-		// the same dirstore options.
-		tpmOpts = append(tpmOpts, ParseTPMOptions(u)...)
+		if device := u.Get("device"); device != "" {
+			tpmOpts = append(tpmOpts, tpm.WithDeviceName(device))
+		}
 	}
 
 	t, err := tpm.New(tpmOpts...)

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -200,6 +200,10 @@ func ParseTPMOptions(u *uri.URI) []tpm.NewTPMOption {
 	return opts
 }
 
+// newDirstore constructs the dirstore backing a [New] TPMKMS. It is a package
+// var so tests can observe the storage directory and options New resolves.
+var newDirstore = storage.NewDirstore
+
 // resolveStorageDirectory returns the TPM storage directory and dirstore
 // options that [New] uses for the given options and parsed URI. The directory
 // precedence is: a storage-directory in the URI wins, otherwise
@@ -424,7 +428,7 @@ func New(ctx context.Context, opts apiv1.Options) (kms *TPMKMS, err error) {
 
 	storageDirectory, dirstoreOptions := resolveStorageDirectory(opts, u)
 	tpmOpts := []tpm.NewTPMOption{
-		tpm.WithStore(storage.NewDirstore(storageDirectory, dirstoreOptions...)),
+		tpm.WithStore(newDirstore(storageDirectory, dirstoreOptions...)),
 	}
 	if u != nil {
 		if device := u.Get("device"); device != "" {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -195,7 +195,22 @@ func ParseTPMOptions(u *uri.URI) []tpm.NewTPMOption {
 		opts = append(opts, tpm.WithDeviceName(device))
 	}
 	if storageDirectory := u.Get("storage-directory"); storageDirectory != "" {
-		opts = append(opts, tpm.WithStore(storage.NewDirstore(storageDirectory)))
+		opts = append(opts, tpm.WithStore(storage.NewDirstore(storageDirectory, parseDirstoreOptions(u)...)))
+	}
+	return opts
+}
+
+// parseDirstoreOptions returns the [storage.DirstoreOption]s encoded in the
+// URI. It currently supports storage-cache-size, the maximum size in bytes of
+// the dirstore's in-memory read cache; setting it to 0 disables caching so
+// every read reflects the current on-disk state. A negative value is ignored.
+func parseDirstoreOptions(u *uri.URI) []storage.DirstoreOption {
+	if u == nil {
+		return nil
+	}
+	var opts []storage.DirstoreOption
+	if size := u.GetInt("storage-cache-size"); size != nil && *size >= 0 {
+		opts = append(opts, storage.WithCacheSize(uint64(*size)))
 	}
 	return opts
 }
@@ -371,24 +386,29 @@ const (
 // your use case, use a tpm.TPM instance instead.
 func New(ctx context.Context, opts apiv1.Options) (kms *TPMKMS, err error) {
 	var uriOptions []Option
+	var u *uri.URI
+
+	// Parse the URI up front so the default store below can honor any storage
+	// options it carries (e.g. storage-cache-size).
+	if opts.URI != "" {
+		if u, err = uri.ParseWithScheme(Scheme, opts.URI); err != nil {
+			return nil, fmt.Errorf("failed parsing %q as URI: %w", opts.URI, err)
+		}
+		uriOptions = ParseOptions(u)
+	}
 
 	storageDirectory := "tpm" // store TPM objects in a relative tpm directory by default.
 	if opts.StorageDirectory != "" {
 		storageDirectory = opts.StorageDirectory
 	}
 	tpmOpts := []tpm.NewTPMOption{
-		tpm.WithStore(storage.NewDirstore(storageDirectory)),
+		tpm.WithStore(storage.NewDirstore(storageDirectory, parseDirstoreOptions(u)...)),
 	}
-
-	// Get other options from URI
-	if opts.URI != "" {
-		u, err := uri.ParseWithScheme(Scheme, opts.URI)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing %q as URI: %w", opts.URI, err)
-		}
-
+	if u != nil {
+		// When the URI carries its own storage-directory this appends a second
+		// WithStore that overrides the default above; ParseTPMOptions applies
+		// the same dirstore options.
 		tpmOpts = append(tpmOpts, ParseTPMOptions(u)...)
-		uriOptions = ParseOptions(u)
 	}
 
 	t, err := tpm.New(tpmOpts...)

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -202,15 +202,22 @@ func ParseTPMOptions(u *uri.URI) []tpm.NewTPMOption {
 
 // parseDirstoreOptions returns the [storage.DirstoreOption]s encoded in the
 // URI. It currently supports storage-cache-size, the maximum size in bytes of
-// the dirstore's in-memory read cache; setting it to 0 disables caching so
-// every read reflects the current on-disk state. A negative value is ignored.
+// the dirstore's in-memory read cache; setting it to 0 (or any negative value)
+// disables caching so every read reflects the current on-disk state.
 func parseDirstoreOptions(u *uri.URI) []storage.DirstoreOption {
 	if u == nil {
 		return nil
 	}
 	var opts []storage.DirstoreOption
-	if size := u.GetInt("storage-cache-size"); size != nil && *size >= 0 {
-		opts = append(opts, storage.WithCacheSize(uint64(*size)))
+	if size := u.GetInt("storage-cache-size"); size != nil {
+		// A negative size is meaningless for a cache budget; treat it as 0
+		// (disabled) rather than silently keeping the default — less surprising
+		// than ignoring it.
+		cacheSize := uint64(0)
+		if *size > 0 {
+			cacheSize = uint64(*size)
+		}
+		opts = append(opts, storage.WithCacheSize(cacheSize))
 	}
 	return opts
 }

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -12,9 +12,60 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.step.sm/crypto/kms/apiv1"
+	"go.step.sm/crypto/kms/uri"
 	"go.step.sm/crypto/tpm"
+	"go.step.sm/crypto/tpm/storage"
 	"go.step.sm/crypto/tpm/tss2"
 )
+
+func TestParseDirstoreOptions(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, rawURI string) *uri.URI {
+		if rawURI == "" {
+			return nil
+		}
+		u, err := uri.ParseWithScheme(Scheme, rawURI)
+		require.NoError(t, err)
+		return u
+	}
+
+	tests := []struct {
+		name string
+		uri  string
+		// reflectsDelete is true when the resulting store has caching disabled,
+		// so a blob deleted by another handle is observed on the next read.
+		reflectsDelete bool
+	}{
+		{"nil-uri", "", false},
+		{"no-cache-param", "tpmkms:storage-directory=x", false},
+		{"cache-disabled", "tpmkms:storage-cache-size=0", true},
+		{"cache-custom", "tpmkms:storage-cache-size=4096", false},
+		{"negative-ignored", "tpmkms:storage-cache-size=-1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			writer := storage.NewDirstore(dir)
+			require.NoError(t, writer.AddAK(&storage.AK{Name: "ak"}))
+
+			reader := storage.NewDirstore(dir, parseDirstoreOptions(parse(t, tt.uri))...)
+			_, err := reader.GetAK("ak") // populate the cache when enabled
+			require.NoError(t, err)
+
+			require.NoError(t, writer.DeleteAK("ak")) // out-of-band delete
+
+			_, err = reader.GetAK("ak")
+			if tt.reflectsDelete {
+				require.ErrorIs(t, err, storage.ErrNotFound)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestNew(t *testing.T) {
 	type args struct {

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -41,7 +41,7 @@ func TestParseDirstoreOptions(t *testing.T) {
 		{"no-cache-param", "tpmkms:storage-directory=x", false},
 		{"cache-disabled", "tpmkms:storage-cache-size=0", true},
 		{"cache-custom", "tpmkms:storage-cache-size=4096", false},
-		{"negative-ignored", "tpmkms:storage-cache-size=-1", false},
+		{"negative-disables", "tpmkms:storage-cache-size=-1", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -108,6 +108,51 @@ func TestResolveStorageDirectory(t *testing.T) {
 	}
 }
 
+// TestNew_storeConstruction drives New and asserts the storage directory and
+// cache size it actually builds the backing dirstore with, via the newDirstore
+// seam. It is the end-to-end counterpart to TestResolveStorageDirectory.
+func TestNew_storeConstruction(t *testing.T) {
+	// New mutates the package-level newDirstore seam, so run serially.
+	orig := newDirstore
+	t.Cleanup(func() { newDirstore = orig })
+
+	tests := []struct {
+		name    string
+		opts    apiv1.Options
+		wantDir string
+		// wantCache is the expected CacheSize; when defaultCache is set, only
+		// that caching stays enabled is asserted (no coupling to the constant).
+		wantCache    uint64
+		defaultCache bool
+	}{
+		{"opts directory, default cache", apiv1.Options{StorageDirectory: "opts-dir"}, "opts-dir", 0, true},
+		{"uri overrides opts directory", apiv1.Options{StorageDirectory: "opts-dir", URI: "tpmkms:storage-directory=uri-dir"}, "uri-dir", 0, true},
+		{"cache disabled", apiv1.Options{StorageDirectory: "opts-dir", URI: "tpmkms:storage-cache-size=0"}, "opts-dir", 0, false},
+		{"cache custom", apiv1.Options{StorageDirectory: "opts-dir", URI: "tpmkms:storage-cache-size=4096"}, "opts-dir", 4096, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotDir string
+			var gotStore *storage.Dirstore
+			newDirstore = func(dir string, opts ...storage.DirstoreOption) *storage.Dirstore {
+				gotDir = dir
+				gotStore = orig(dir, opts...)
+				return gotStore
+			}
+
+			_, err := New(context.Background(), tt.opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDir, gotDir)
+			require.NotNil(t, gotStore)
+			if tt.defaultCache {
+				require.NotZero(t, gotStore.CacheSize(), "expected caching enabled by default")
+			} else {
+				require.Equal(t, tt.wantCache, gotStore.CacheSize())
+			}
+		})
+	}
+}
+
 func TestNew(t *testing.T) {
 	type args struct {
 		opts apiv1.Options

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -77,37 +77,6 @@ func TestParseDirstoreOptions(t *testing.T) {
 	}
 }
 
-// TestResolveStorageDirectory covers the directory + cache-size resolution that
-// New performs: the URI's storage-directory wins over opts.StorageDirectory,
-// which wins over the default "tpm", and storage-cache-size threads through.
-func TestResolveStorageDirectory(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		opts          apiv1.Options
-		uri           string
-		wantDir       string
-		cacheDisabled bool
-	}{
-		{"default", apiv1.Options{}, "", "tpm", false},
-		{"opts-directory", apiv1.Options{StorageDirectory: "opts-dir"}, "", "opts-dir", false},
-		{"uri-directory", apiv1.Options{}, "tpmkms:storage-directory=uri-dir", "uri-dir", false},
-		{"uri-overrides-opts", apiv1.Options{StorageDirectory: "opts-dir"}, "tpmkms:storage-directory=uri-dir", "uri-dir", false},
-		{"cache-disabled-keeps-opts-dir", apiv1.Options{StorageDirectory: "opts-dir"}, "tpmkms:storage-cache-size=0", "opts-dir", true},
-		{"uri-directory-and-cache", apiv1.Options{}, "tpmkms:storage-directory=uri-dir;storage-cache-size=0", "uri-dir", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			dir, dirOpts := resolveStorageDirectory(tt.opts, parseTestURI(t, tt.uri))
-			require.Equal(t, tt.wantDir, dir)
-			assertCacheDisabled(t, dirOpts, tt.cacheDisabled)
-		})
-	}
-}
-
 // TestNew_storeConstruction drives New and asserts the storage directory and
 // cache size it actually builds the backing dirstore with, via the newDirstore
 // seam. It is the end-to-end counterpart to TestResolveStorageDirectory.
@@ -125,6 +94,7 @@ func TestNew_storeConstruction(t *testing.T) {
 		wantCache    uint64
 		defaultCache bool
 	}{
+		{"default directory and cache", apiv1.Options{}, "tpm", 0, true},
 		{"opts directory, default cache", apiv1.Options{StorageDirectory: "opts-dir"}, "opts-dir", 0, true},
 		{"uri overrides opts directory", apiv1.Options{StorageDirectory: "opts-dir", URI: "tpmkms:storage-directory=uri-dir"}, "uri-dir", 0, true},
 		{"cache disabled", apiv1.Options{StorageDirectory: "opts-dir", URI: "tpmkms:storage-cache-size=0"}, "opts-dir", 0, false},

--- a/kms/tpmkms/tpmkms_test.go
+++ b/kms/tpmkms/tpmkms_test.go
@@ -18,17 +18,43 @@ import (
 	"go.step.sm/crypto/tpm/tss2"
 )
 
+// parseTestURI parses rawURI as a tpmkms URI, or returns nil for "".
+func parseTestURI(t *testing.T, rawURI string) *uri.URI {
+	t.Helper()
+	if rawURI == "" {
+		return nil
+	}
+	u, err := uri.ParseWithScheme(Scheme, rawURI)
+	require.NoError(t, err)
+	return u
+}
+
+// assertCacheDisabled applies dirOpts to a fresh dirstore and asserts whether an
+// out-of-band delete by a second handle is reflected (cache disabled) or masked
+// (cache enabled) on the reader's next read.
+func assertCacheDisabled(t *testing.T, dirOpts []storage.DirstoreOption, disabled bool) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writer := storage.NewDirstore(dir)
+	require.NoError(t, writer.AddAK(&storage.AK{Name: "ak"}))
+
+	reader := storage.NewDirstore(dir, dirOpts...)
+	_, err := reader.GetAK("ak") // populate the cache when enabled
+	require.NoError(t, err)
+
+	require.NoError(t, writer.DeleteAK("ak")) // out-of-band delete
+
+	_, err = reader.GetAK("ak")
+	if disabled {
+		require.ErrorIs(t, err, storage.ErrNotFound)
+	} else {
+		require.NoError(t, err)
+	}
+}
+
 func TestParseDirstoreOptions(t *testing.T) {
 	t.Parallel()
-
-	parse := func(t *testing.T, rawURI string) *uri.URI {
-		if rawURI == "" {
-			return nil
-		}
-		u, err := uri.ParseWithScheme(Scheme, rawURI)
-		require.NoError(t, err)
-		return u
-	}
 
 	tests := []struct {
 		name string
@@ -46,23 +72,38 @@ func TestParseDirstoreOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			assertCacheDisabled(t, parseDirstoreOptions(parseTestURI(t, tt.uri)), tt.reflectsDelete)
+		})
+	}
+}
 
-			dir := t.TempDir()
-			writer := storage.NewDirstore(dir)
-			require.NoError(t, writer.AddAK(&storage.AK{Name: "ak"}))
+// TestResolveStorageDirectory covers the directory + cache-size resolution that
+// New performs: the URI's storage-directory wins over opts.StorageDirectory,
+// which wins over the default "tpm", and storage-cache-size threads through.
+func TestResolveStorageDirectory(t *testing.T) {
+	t.Parallel()
 
-			reader := storage.NewDirstore(dir, parseDirstoreOptions(parse(t, tt.uri))...)
-			_, err := reader.GetAK("ak") // populate the cache when enabled
-			require.NoError(t, err)
+	tests := []struct {
+		name          string
+		opts          apiv1.Options
+		uri           string
+		wantDir       string
+		cacheDisabled bool
+	}{
+		{"default", apiv1.Options{}, "", "tpm", false},
+		{"opts-directory", apiv1.Options{StorageDirectory: "opts-dir"}, "", "opts-dir", false},
+		{"uri-directory", apiv1.Options{}, "tpmkms:storage-directory=uri-dir", "uri-dir", false},
+		{"uri-overrides-opts", apiv1.Options{StorageDirectory: "opts-dir"}, "tpmkms:storage-directory=uri-dir", "uri-dir", false},
+		{"cache-disabled-keeps-opts-dir", apiv1.Options{StorageDirectory: "opts-dir"}, "tpmkms:storage-cache-size=0", "opts-dir", true},
+		{"uri-directory-and-cache", apiv1.Options{}, "tpmkms:storage-directory=uri-dir;storage-cache-size=0", "uri-dir", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-			require.NoError(t, writer.DeleteAK("ak")) // out-of-band delete
-
-			_, err = reader.GetAK("ak")
-			if tt.reflectsDelete {
-				require.ErrorIs(t, err, storage.ErrNotFound)
-			} else {
-				require.NoError(t, err)
-			}
+			dir, dirOpts := resolveStorageDirectory(tt.opts, parseTestURI(t, tt.uri))
+			require.Equal(t, tt.wantDir, dir)
+			assertCacheDisabled(t, dirOpts, tt.cacheDisabled)
 		})
 	}
 }

--- a/tpm/storage/dirstore.go
+++ b/tpm/storage/dirstore.go
@@ -88,6 +88,12 @@ func NewDirstore(directory string, opts ...DirstoreOption) *Dirstore {
 	}
 }
 
+// CacheSize returns the maximum size, in bytes, of the in-memory read cache the
+// Dirstore keeps in front of the on-disk store. Zero means caching is disabled.
+func (s *Dirstore) CacheSize() uint64 {
+	return s.store.CacheSizeMax
+}
+
 func (s *Dirstore) ListKeys() ([]*Key, error) {
 	var result = make([]*Key, 0)
 	c := s.store.KeysPrefix(keyPrefix, nil)

--- a/tpm/storage/dirstore.go
+++ b/tpm/storage/dirstore.go
@@ -43,14 +43,45 @@ func inverseTransform(pathKey *diskv.PathKey) (key string) {
 	return
 }
 
+// defaultCacheSizeMax is the default upper bound, in bytes, for the in-memory
+// cache the backing diskv store keeps in front of the on-disk files.
+const defaultCacheSizeMax = 1024 * 1024
+
+// dirstoreOptions holds the configurable settings for a [Dirstore].
+type dirstoreOptions struct {
+	cacheSizeMax uint64
+}
+
+// DirstoreOption configures a [Dirstore] created with [NewDirstore].
+type DirstoreOption func(*dirstoreOptions)
+
+// WithCacheSize sets the maximum size, in bytes, of the in-memory cache the
+// [Dirstore] keeps in front of the on-disk store. A value of 0 disables
+// caching entirely, so every read hits disk.
+//
+// Disabling the cache is useful when the backing directory may be mutated by
+// another handle out of band (for example, a stale key blob deleted by a
+// separate store instance): with caching enabled a previously read value would
+// still be served from memory, whereas an uncached store always reflects the
+// current on-disk state.
+func WithCacheSize(size uint64) DirstoreOption {
+	return func(o *dirstoreOptions) {
+		o.cacheSizeMax = size
+	}
+}
+
 // NewDirstore creates a new instance of a Direstore.
-func NewDirstore(directory string) *Dirstore {
+func NewDirstore(directory string, opts ...DirstoreOption) *Dirstore {
+	o := &dirstoreOptions{cacheSizeMax: defaultCacheSizeMax}
+	for _, opt := range opts {
+		opt(o)
+	}
 	return &Dirstore{
 		store: diskv.New(diskv.Options{
 			BasePath:          directory,
 			AdvancedTransform: advancedTransform,
 			InverseTransform:  inverseTransform,
-			CacheSizeMax:      1024 * 1024,
+			CacheSizeMax:      o.cacheSizeMax,
 			// TODO(hs): add TempDir for atomic operations?
 		}),
 		directory: directory,

--- a/tpm/storage/dirstore_test.go
+++ b/tpm/storage/dirstore_test.go
@@ -37,6 +37,74 @@ func Test_inverseTransform(t *testing.T) {
 	assert.Equal(t, "/path/to/file", got)
 }
 
+func TestNewDirstore_cacheSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		store := NewDirstore(t.TempDir())
+		assert.Equal(t, uint64(defaultCacheSizeMax), store.store.CacheSizeMax)
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Parallel()
+		store := NewDirstore(t.TempDir(), WithCacheSize(4096))
+		assert.Equal(t, uint64(4096), store.store.CacheSizeMax)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
+		store := NewDirstore(t.TempDir(), WithCacheSize(0))
+		assert.Equal(t, uint64(0), store.store.CacheSizeMax)
+	})
+}
+
+// TestDirstore_noCacheReflectsOutOfBandDelete verifies that with caching
+// disabled a Dirstore reflects a blob deleted by a separate handle, whereas the
+// default cached store keeps serving the stale value it previously read. This
+// is the property that lets the agent probe an AK blob and observe its deletion
+// without rebuilding the store handle.
+func TestDirstore_noCacheReflectsOutOfBandDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cached serves stale read", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writer := NewDirstore(dir)
+		require.NoError(t, writer.AddAK(&AK{Name: "ak"}))
+
+		reader := NewDirstore(dir)
+		ak, err := reader.GetAK("ak") // populates reader's cache
+		require.NoError(t, err)
+		require.Equal(t, "ak", ak.Name)
+
+		require.NoError(t, writer.DeleteAK("ak")) // out-of-band delete
+
+		// The cached reader still reports the AK as present.
+		ak, err = reader.GetAK("ak")
+		require.NoError(t, err)
+		require.Equal(t, "ak", ak.Name)
+	})
+
+	t.Run("uncached reflects delete", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writer := NewDirstore(dir)
+		require.NoError(t, writer.AddAK(&AK{Name: "ak"}))
+
+		reader := NewDirstore(dir, WithCacheSize(0))
+		ak, err := reader.GetAK("ak")
+		require.NoError(t, err)
+		require.Equal(t, "ak", ak.Name)
+
+		require.NoError(t, writer.DeleteAK("ak")) // out-of-band delete
+
+		// The uncached reader reflects the current on-disk state.
+		_, err = reader.GetAK("ak")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
 func TestDirstore_KeyOperations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`NewDirstore` hardcoded the diskv in-memory read cache at 1 MiB. Because a store handle serves a key/AK blob from that cache after its first read, a handle keeps returning a blob even after a *separate* handle deletes it from the backing directory. Callers that mutate the directory out of band therefore have to rebuild their store handle to observe the change.

This adds a way to disable (or size) that cache.

## Changes

- **`tpm/storage`**: `NewDirstore(directory string, opts ...DirstoreOption)` is now variadic (backward compatible; existing callers keep the 1 MiB default). New `WithCacheSize(bytes uint64)` option; `0` disables caching so every read reflects current on-disk state.
- **`kms/tpmkms`**: thread the setting through the `storage-cache-size` URI parameter, parsed in both `ParseTPMOptions` and `New`. `New` now parses the URI before constructing the default store, so the setting is honored regardless of whether the storage directory comes from the URI or `apiv1.Options.StorageDirectory`.

## Motivation

The smallstep agent hit this on Windows: it recovers from an "orphaned AK" (blob present, backing PCP/CNG key deleted) by deleting the stale blob and letting the KMS recreate the AK. Its probe TPM handle had already cached the dead blob, forcing a handle rebuild after deletion. With `storage-cache-size=0` the probe handle reflects the deletion directly and the rebuild goes away. (Loading a key into the TPM dwarfs a blob read from disk, so caching that read buys little here.)

## Testing

- `TestNewDirstore_cacheSize` — default / custom / disabled map to the right `CacheSizeMax`.
- `TestDirstore_noCacheReflectsOutOfBandDelete` — a cached store serves a stale blob after an out-of-band delete; an uncached store reflects the delete.
- `TestParseDirstoreOptions` — URIs (`nil`, absent, `=0`, `=4096`, negative) thread through to the expected cache behavior via the public store API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)