### PR TITLE
Say when a failed PIN verification tried the default PIN

### DIFF
--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -126,6 +126,7 @@ CErVHSJIs+BdtTVNY9AwtyPmnyb0v4mSTzvWdw==
 type YubiKey struct {
 	yk            pivKey
 	pin           string
+	defaultPIN    bool
 	card          string
 	managementKey []byte
 }
@@ -197,7 +198,9 @@ const maximumManagementKeyLength = 32
 //	yubikey:slot-id=9a?pin-value=123456
 //
 // If the pin or the management key are not provided, we will use the default
-// ones.
+// ones. Note that a failed PIN verification consumes one of the card's PIN
+// retries, so if the card does not use the default PIN, always provide it
+// with pin-value, pin-source or pin-prompt.
 func New(_ context.Context, opts apiv1.Options) (*YubiKey, error) {
 	pin := "123456"
 	var managementKey [maximumManagementKeyLength]byte
@@ -244,7 +247,8 @@ func New(_ context.Context, opts apiv1.Options) (*YubiKey, error) {
 		copy(managementKey[:managementKeyLength], b[:managementKeyLength])
 	}
 
-	if opts.Pin != "" {
+	defaultPIN := opts.Pin == ""
+	if !defaultPIN {
 		pin = opts.Pin
 	}
 
@@ -281,6 +285,7 @@ func New(_ context.Context, opts apiv1.Options) (*YubiKey, error) {
 	return &YubiKey{
 		yk:            yk,
 		pin:           pin,
+		defaultPIN:    defaultPIN,
 		card:          card,
 		managementKey: managementKey[:managementKeyLength],
 	}, nil
@@ -406,7 +411,8 @@ func (k *YubiKey) CreateSigner(req *apiv1.CreateSignerRequest) (crypto.Signer, e
 		return nil, errors.New("private key is not a crypto.Signer")
 	}
 	return &syncSigner{
-		Signer: signer,
+		Signer:     signer,
+		defaultPIN: k.defaultPIN,
 	}, nil
 }
 
@@ -444,7 +450,8 @@ func (k *YubiKey) CreateDecrypter(req *apiv1.CreateDecrypterRequest) (crypto.Dec
 		return nil, errors.New("private key is not a crypto.Decrypter")
 	}
 	return &syncDecrypter{
-		Decrypter: decrypter,
+		Decrypter:  decrypter,
+		defaultPIN: k.defaultPIN,
 	}, nil
 }
 
@@ -712,12 +719,14 @@ var m sync.Mutex
 // error 6982: security status not satisfied" with two concurrent signs.
 type syncSigner struct {
 	crypto.Signer
+	defaultPIN bool
 }
 
 func (s *syncSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	m.Lock()
 	defer m.Unlock()
-	return s.Signer.Sign(rand, digest, opts)
+	sig, err := s.Signer.Sign(rand, digest, opts)
+	return sig, wrapPINError(err, s.defaultPIN)
 }
 
 // syncDecrypter wraps a crypto.Decrypter with a mutex to avoid the error "smart
@@ -725,12 +734,30 @@ func (s *syncSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts)
 // concurrent decryptions.
 type syncDecrypter struct {
 	crypto.Decrypter
+	defaultPIN bool
 }
 
 func (s *syncDecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
 	m.Lock()
 	defer m.Unlock()
-	return s.Decrypter.Decrypt(rand, msg, opts)
+	plain, err := s.Decrypter.Decrypt(rand, msg, opts)
+	return plain, wrapPINError(err, s.defaultPIN)
+}
+
+// wrapPINError explains where the PIN came from when PIN verification fails
+// and no PIN was ever provided: New falls back to the YubiKey factory default
+// PIN, each failed verification consumes one of the card's PIN retries, and
+// without this context the error reads as if the user mistyped a PIN that
+// this package chose itself.
+func wrapPINError(err error, defaultPIN bool) error {
+	if err == nil || !defaultPIN {
+		return err
+	}
+	var authErr piv.AuthErr
+	if !errors.As(err, &authErr) {
+		return err
+	}
+	return fmt.Errorf("%w; the YubiKey factory default PIN was tried because no PIN was available; provide one with pin-value, pin-source or pin-prompt", err)
 }
 
 var _ apiv1.CertificateManager = (*YubiKey)(nil)

--- a/kms/yubikey/yubikey_test.go
+++ b/kms/yubikey/yubikey_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -351,7 +352,7 @@ func TestNew(t *testing.T) {
 			pivMap = sync.Map{}
 			pivCards = okPivCards
 			pivOpen = okPivOpen
-		}, &YubiKey{yk: yk, pin: "123456", card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: piv.DefaultManagementKey}, false},
+		}, &YubiKey{yk: yk, pin: "123456", defaultPIN: true, card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: piv.DefaultManagementKey}, false},
 		{"ok with uri", args{ctx, apiv1.Options{
 			URI: "yubikey:pin-value=111111;management-key=001122334455667788990011223344556677889900112233",
 		}}, func() {
@@ -398,11 +399,18 @@ func TestNew(t *testing.T) {
 			pivCards = okPivCards
 			pivOpen = okPivOpen
 		}, &YubiKey{yk: yk, pin: "222222", card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: piv.DefaultManagementKey}, false},
+		{"ok with missing pin-source", args{ctx, apiv1.Options{
+			URI: "yubikey:pin-source=" + filepath.Join(t.TempDir(), "missing.pin"),
+		}}, func() {
+			pivMap = sync.Map{}
+			pivCards = okPivCards
+			pivOpen = okPivOpen
+		}, &YubiKey{yk: yk, pin: "123456", defaultPIN: true, card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: piv.DefaultManagementKey}, false},
 		{"ok with ManagementKey", args{ctx, apiv1.Options{ManagementKey: "001122334455667788990011223344556677889900112233"}}, func() {
 			pivMap = sync.Map{}
 			pivCards = okPivCards
 			pivOpen = okPivOpen
-		}, &YubiKey{yk: yk, pin: "123456", card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0x11, 0x22, 0x33}}, false},
+		}, &YubiKey{yk: yk, pin: "123456", defaultPIN: true, card: "Yubico YubiKey OTP+FIDO+CCID", managementKey: []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0x11, 0x22, 0x33}}, false},
 		{"fail uri", args{ctx, apiv1.Options{URI: "badschema:"}}, func() {
 			pivMap = sync.Map{}
 			pivCards = okPivCards
@@ -1390,6 +1398,140 @@ func Test_syncDecrypter_Decrypt(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, data, plain)
+}
+
+type failingSigner struct {
+	err error
+}
+
+func (f failingSigner) Public() crypto.PublicKey { return nil }
+
+func (f failingSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, f.err
+}
+
+type failingDecrypter struct {
+	err error
+}
+
+func (f failingDecrypter) Public() crypto.PublicKey { return nil }
+
+func (f failingDecrypter) Decrypt(io.Reader, []byte, crypto.DecrypterOpts) ([]byte, error) {
+	return nil, f.err
+}
+
+func Test_wrapPINError(t *testing.T) {
+	pinErr := fmt.Errorf("verify pin: %w", piv.AuthErr{Retries: 2})
+	blockedErr := fmt.Errorf("verify pin: %w", piv.AuthErr{})
+	otherErr := errors.New("some error")
+
+	type args struct {
+		err        error
+		defaultPIN bool
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantHint    bool
+		wantRetries int
+	}{
+		{"wraps auth errors from the default pin", args{pinErr, true}, true, 2},
+		{"wraps blocked pin errors from the default pin", args{blockedErr, true}, true, 0},
+		{"skips auth errors from a provided pin", args{pinErr, false}, false, 0},
+		{"skips other errors", args{otherErr, true}, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := wrapPINError(tt.args.err, tt.args.defaultPIN)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.args.err)
+			if tt.wantHint {
+				assert.Contains(t, err.Error(), "the YubiKey factory default PIN was tried")
+				var authErr piv.AuthErr
+				require.ErrorAs(t, err, &authErr)
+				assert.Equal(t, tt.wantRetries, authErr.Retries)
+			} else {
+				assert.NotContains(t, err.Error(), "default PIN")
+			}
+		})
+	}
+
+	assert.NoError(t, wrapPINError(nil, true))
+	assert.NoError(t, wrapPINError(nil, false))
+}
+
+func TestYubiKey_CreateSigner_defaultPIN(t *testing.T) {
+	pinErr := fmt.Errorf("verify pin: %w", piv.AuthErr{Retries: 2})
+
+	yk := newStubPivKey(t, ECDSA)
+	yk.signerMap[piv.SlotSignature] = failingSigner{err: pinErr}
+
+	tests := []struct {
+		name       string
+		defaultPIN bool
+		wantHint   bool
+	}{
+		{"hints when the pin was defaulted", true, true},
+		{"does not hint when the pin was provided", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &YubiKey{yk: yk, pin: "123456", defaultPIN: tt.defaultPIN, managementKey: piv.DefaultManagementKey}
+			signer, err := k.CreateSigner(&apiv1.CreateSignerRequest{
+				SigningKey: "yubikey:slot-id=9c",
+			})
+			require.NoError(t, err)
+
+			_, err = signer.Sign(rand.Reader, []byte("digest"), crypto.SHA256)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, pinErr)
+			var authErr piv.AuthErr
+			require.ErrorAs(t, err, &authErr)
+			assert.Equal(t, 2, authErr.Retries)
+			if tt.wantHint {
+				assert.Contains(t, err.Error(), "the YubiKey factory default PIN was tried")
+			} else {
+				assert.NotContains(t, err.Error(), "default PIN")
+			}
+		})
+	}
+}
+
+func TestYubiKey_CreateDecrypter_defaultPIN(t *testing.T) {
+	pinErr := fmt.Errorf("verify pin: %w", piv.AuthErr{Retries: 2})
+
+	yk := newStubPivKey(t, RSA)
+	yk.signerMap[piv.SlotSignature] = failingDecrypter{err: pinErr}
+
+	tests := []struct {
+		name       string
+		defaultPIN bool
+		wantHint   bool
+	}{
+		{"hints when the pin was defaulted", true, true},
+		{"does not hint when the pin was provided", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &YubiKey{yk: yk, pin: "123456", defaultPIN: tt.defaultPIN, managementKey: piv.DefaultManagementKey}
+			decrypter, err := k.CreateDecrypter(&apiv1.CreateDecrypterRequest{
+				DecryptionKey: "yubikey:slot-id=9c",
+			})
+			require.NoError(t, err)
+
+			_, err = decrypter.Decrypt(rand.Reader, []byte("ciphertext"), nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, pinErr)
+			var authErr piv.AuthErr
+			require.ErrorAs(t, err, &authErr)
+			assert.Equal(t, 2, authErr.Retries)
+			if tt.wantHint {
+				assert.Contains(t, err.Error(), "the YubiKey factory default PIN was tried")
+			} else {
+				assert.NotContains(t, err.Error(), "default PIN")
+			}
+		})
+	}
 }
 
 func TestYubicoNewRoots(t *testing.T) {


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Bug fix: when a PIN verification fails and the PIN in use was the library's fallback — the YubiKey factory default — the error now says so, and names the URI options that provide the right one.


#### Pain or issue this feature alleviates:

When no PIN is provided, `New` falls back to the YubiKey factory default PIN `123456` (documented, intentional). The trouble is what happens when the card's PIN is *not* the default: `CreateSigner` and `CreateDecrypter` pass the guessed PIN with `piv.PINPolicyAlways`, so every `Sign` or `Decrypt` sends a `VERIFY` with a wrong PIN. Each attempt consumes one of the card's PIN retries (3 by default), and the error the user sees is:

```
verify pin: smart card error 63c2: verification failed (2 retries remaining)
```

Nothing tells the user the library chose that PIN itself — the error reads like a typo in a PIN they never typed. Retrying the same innocent command twice more blocks the PIN, and a blocked PIN means a PUK ceremony or, as in smallstep/cli#1492, a PIV reset that destroys the PIV keys. In #1492 the user's `pin-value` was correct but didn't reach the `step-kms-plugin` subprocess; the silent fallback did the rest, and the maintainer confirmed the only way out was a reset. step-kms-plugin#83 shows the same opaque error confusing another user.

With this change the same failure reads:

```
verify pin: smart card error 63c2: verification failed (2 retries remaining); the YubiKey factory default PIN was tried because no PIN was available; provide one with pin-value, pin-source or pin-prompt
```

which is self-diagnosing before the last retry is gone. The clause says "no PIN was available" rather than "was provided" deliberately: `uri.Pin()` also resolves empty when a `pin-source` file is unreadable or a `pin-prompt` has no terminal, and the message stays true in those cases too.

#### Why is this important to the project (if not answered above):

This library drives an HSM-like device where the failure budget by default is three attempts, and typical CLI usage (`step` → `step-kms-plugin`) spends one process invocation — and therefore one silent `VERIFY` — per operation. A misconfiguration that costs nothing anywhere else in the KMS surface here consumes an unrecoverable hardware resource. The default-PIN fallback itself is reasonable and stays exactly as documented; the fix is only that failing with a PIN the user never chose now says so.

`New` records whether the PIN came from the options or from the fallback, `syncSigner`/`syncDecrypter` carry that flag, and a small helper appends the context when the error matches `piv.AuthErr` (which also covers `6983: authentication method blocked` — the "last retry already gone" case). Errors from an explicitly provided PIN — including an explicit `pin-value=123456` — are untouched, as is every success path and every non-PIN error.

#### Is there documentation on how to use this feature? If so, where?

No usage change. `New`'s doc comment now warns that a failed PIN verification consumes one of the card's PIN retries and points at `pin-value`, `pin-source` and `pin-prompt` (the prompt option added in #810). The error message itself is the documentation that matters: it names the three URI options at the moment the user needs them.

#### In what environments or workflows is this feature supported?

All platforms the yubikey KMS builds on (build tag `cgo && !noyubikey`). The new tests are hardware-free (stubbed `pivCards`/`pivOpen`, a failing signer/decrypter injected into the stub) and run in CI: they pin the wrapped message, that `errors.Is`/`errors.As` still reach the original error and `piv.AuthErr` through the wrap (including the blocked-PIN `AuthErr{0}` case), that no hint appears when a PIN was provided, and that an unreadable `pin-source` falls back to the default with `defaultPIN` provenance recorded. Manually verified on a spare YubiKey 4 (fw 4.3.3, pcsc-lite, 32-bit Linux) with a non-default PIN: the unpatched library burned a real retry with the opaque `63c2 ... (2 retries remaining)` error; the patched library burned one with the self-diagnosing error (correctly rendering piv-go's singular "1 retry remaining"); a sign with the correct `pin-value` then succeeded and the card reset its retry counter to 3. Full package suite also run on Windows amd64 (CGO_ENABLED=1) and the same 32-bit Linux box. What CI cannot catch: it runs Linux-only with no PC/SC stack or card hardware, so the real VERIFY exchange, the retry-counter decrement, and the end-to-end rendering of this error rest on the manual verification above — the stubbed tests cover everything else.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

No behavior change: same PINs sent, same operations, same error values (`errors.Is`/`errors.As` compatible) — only the message gains a suffix, and only when the fallback PIN was the one that failed. Code that string-matches the exact old error text would see the suffix; error-value comparisons are unaffected.

#### Supporting links/other PRs/issues:

- Fixes #1074
- smallstep/cli#1492 — a locked YubiKey and forced reset caused by exactly this silent fallback (maintainer-confirmed)
- smallstep/step-kms-plugin#83 — the same `63c2 ... retries remaining` error confusing a user with a non-default PIN
- #810 — the `pin-prompt` URI option this error now advertises
- FiloSottile/yubikey-agent#132 — the same failure class in another piv-go downstream
- this PR and #1071 (reader selection) touch the same file and overlap textually around `New`; they are logically independent, and I will rebase whichever lands second.

Reviewed and refined with AI assistance; all changes reviewed, run, and verified by me.

💔Thank you!
