### PR TITLE
Hint at a required YubiKey touch on 0x6982 errors

### DIFF
--- a/kms/yubikey/yubikey.go
+++ b/kms/yubikey/yubikey.go
@@ -717,7 +717,8 @@ type syncSigner struct {
 func (s *syncSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	m.Lock()
 	defer m.Unlock()
-	return s.Signer.Sign(rand, digest, opts)
+	sig, err := s.Signer.Sign(rand, digest, opts)
+	return sig, wrapTouchHint(err)
 }
 
 // syncDecrypter wraps a crypto.Decrypter with a mutex to avoid the error "smart
@@ -730,7 +731,27 @@ type syncDecrypter struct {
 func (s *syncDecrypter) Decrypt(rand io.Reader, msg []byte, opts crypto.DecrypterOpts) ([]byte, error) {
 	m.Lock()
 	defer m.Unlock()
-	return s.Decrypter.Decrypt(rand, msg, opts)
+	plaintext, err := s.Decrypter.Decrypt(rand, msg, opts)
+	return plaintext, wrapTouchHint(err)
+}
+
+// wrapTouchHint annotates a 0x6982 "security status not satisfied" card error
+// with a hint that the slot's touch policy may be waiting for a physical touch.
+// The status word is not touch-specific -- it can also mean an unsatisfied PIN
+// or, without the mutex above, concurrent access -- so the hint is conditional.
+//
+// The status is detected through an anonymous interface because piv-go's error
+// type is unexported. If a future piv-go release exposes a sentinel for this
+// status, this can become a plain errors.Is check.
+func wrapTouchHint(err error) error {
+	if err == nil {
+		return nil
+	}
+	var sc interface{ Status() uint16 }
+	if errors.As(err, &sc) && sc.Status() == 0x6982 {
+		return fmt.Errorf("%w; if the key's slot has a touch policy, touch the blinking YubiKey and retry", err)
+	}
+	return err
 }
 
 var _ apiv1.CertificateManager = (*YubiKey)(nil)

--- a/kms/yubikey/yubikey_test.go
+++ b/kms/yubikey/yubikey_test.go
@@ -1459,3 +1459,30 @@ Vpmq2Sh/xT5HiFuhf4wJb0bK
 	}
 
 }
+
+func TestWrapTouchHint(t *testing.T) {
+	// A 0x6982 "security status not satisfied" error gets the touch hint, and the
+	// original error stays unwrappable.
+	base := cardStatusErr(0x6982)
+	got := wrapTouchHint(base)
+	assert.Contains(t, got.Error(), "touch")
+	assert.ErrorIs(t, got, base)
+
+	// A different status word is passed through unchanged.
+	other := cardStatusErr(0x6a80)
+	assert.Equal(t, other.Error(), wrapTouchHint(other).Error())
+	assert.NotContains(t, wrapTouchHint(other).Error(), "touch")
+
+	// A nil error stays nil; a plain error without Status() passes through.
+	assert.NoError(t, wrapTouchHint(nil))
+	plain := errors.New("boom")
+	assert.ErrorIs(t, wrapTouchHint(plain), plain)
+	assert.NotContains(t, wrapTouchHint(plain).Error(), "touch")
+}
+
+// cardStatusErr is a minimal card-style error that exposes Status() like piv-go's
+// unexported apduErr, so wrapTouchHint can be tested without hardware.
+type cardStatusErr uint16
+
+func (e cardStatusErr) Error() string  { return fmt.Sprintf("smart card error %04x", uint16(e)) }
+func (e cardStatusErr) Status() uint16 { return uint16(e) }


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: 

Add a hint to touch the YubiKey when a sign or decrypt fails with card status
`0x6982` ("security status not satisfied").

#### Pain or issue this feature alleviates:

When a YubiKey slot has a touch policy, a sign or decrypt blocks until the key is
physically touched. If the user doesn't touch it, the operation fails with:

```
smart card error 6982: security status not satisfied
```

Nothing in that message says a touch was expected — the key blinks silently and then
the command fails with an opaque status word. (Reported upstream for the plugin in
smallstep/step-kms-plugin#40, where a proactive "touch now" prompt was declined
because the touch policy can't be reliably known up front, but "a generic message"
was suggested. This is that generic message, at the library layer.)

#### Why is this important to the project (if not answered above):

The YubiKey KMS forces `PINPolicyAlways`, so the PIN is verified immediately before
every sign/decrypt. That means a `0x6982` from the operation itself is a missing touch rather than a PIN problem. Turning the bare status word into an actionable hint ("touch the key and retry") directly addresses the most confusing failure mode of touch-policy keys, at essentially zero cost and with no behaviour change on success.

#### Is there documentation on how to use this feature? If so, where?

No new API or documentation. Error output on a `0x6982` failure now ends with
`; if the key's slot has a touch policy, touch the blinking YubiKey and retry`.
Everything else is unchanged.

#### In what environments or workflows is this feature supported?

All platforms; the change is in `syncSigner.Sign` / `syncDecrypter.Decrypt`, which
every YubiKey KMS signer/decrypter goes through. Unit-tested without hardware
(`TestWrapTouchHint`), and the test runs in CI (`make test` builds the yubikey package
with cgo + `libpcsclite-dev`).

Also verified end-to-end on a real YubiKey 4 (slot 9c, `pin=always, touch=always`),
signing through this KMS without touching the key so the card returns `0x6982` after
its ~15 s timeout:

```
before:  command failed: smart card error 6982: security status not satisfied
after:   command failed: smart card error 6982: security status not satisfied; if the key's slot has a touch policy, touch the blinking YubiKey and retry
```

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

The hint is deliberately hedged ("if the key's slot has a touch policy") because
`0x6982` is not touch-specific: it can also indicate an unsatisfied PIN condition, or
— absent the existing mutex — concurrent card access. The code does not (and on older
YubiKeys cannot cheaply) query the slot's touch policy to confirm, so it never asserts
a touch was definitely required.

#### Supporting links/other PRs/issues:

- smallstep/step-kms-plugin#40 — the original "prompt to touch" request; a generic
  message was the accepted path.
- The `0x6982` status is detected through an anonymous `interface{ Status() uint16 }`
  because piv-go's `apduErr` is unexported. A companion piv-go change proposes an
  exported `ErrSecurityStatusNotSatisfied` sentinel [link at file time]; once it ships,
  this detector can become a plain `errors.Is`.
- This touches `syncSigner.Sign` / `syncDecrypter.Decrypt`, the same methods as #1075
  (default-PIN error). The two are independent concerns (`0x6982` vs `AuthErr`) and
  compose as `func(error) error`; whichever merges second, the wraps combine into one
  dispatch (`AuthErr → PIN hint`, `0x6982 → touch hint`).

💔Thank you!
