### PR TITLE
Follow-ups to the certificate searcher: bounds-checked property reads, store handle leaks

### DIFF
--- a/kms/apiv1/options.go
+++ b/kms/apiv1/options.go
@@ -49,7 +49,9 @@ type SearchableKeyManager interface {
 // returned response may still be non-nil and hold the certificates
 // enumerated before the failure, together with a non-nil error describing
 // what went wrong. Callers wanting those partial results must check the
-// response before (or regardless of) the error.
+// response before (or regardless of) the error. A failure to read one
+// certificate's key metadata is reported on that result's Err field rather
+// than failing the search or dropping the certificate.
 //
 // # Experimental
 //

--- a/kms/apiv1/requests.go
+++ b/kms/apiv1/requests.go
@@ -403,6 +403,14 @@ type SearchCertificatesRequest struct {
 type SearchCertificateResult struct {
 	Certificate      *x509.Certificate
 	KeyContainerName string
+
+	// Err is non-nil when the certificate's key-provider metadata could not
+	// be read. Certificate is still valid and KeyContainerName is empty. It
+	// distinguishes a certificate with no private-key association at all
+	// (Err == nil, KeyContainerName == "") from one whose association exists
+	// but cannot be interpreted — a certificate a caller sweeping for broken
+	// credentials most likely wants to see rather than have hidden.
+	Err error
 }
 
 // SearchCertificatesResponse is the response of a SearchCertificates call.

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"math/big"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -405,6 +406,49 @@ func (k *CAPIKMS) Close() error {
 	return nil
 }
 
+// openCertStore opens the system certificate store selected by u. The caller
+// owns the returned handle and must close it with windows.CertCloseStore.
+//
+// Closing it with no flags only drops a reference: a certificate context
+// obtained from a store holds its own reference, so the context stays valid
+// after the store is closed and the store is released once the last context is
+// freed. Callers may therefore close with a defer even when they hand a
+// context back to their own caller. Passing CERT_CLOSE_STORE_FORCE_FLAG would
+// not be safe there, as it closes the store regardless of outstanding
+// contexts.
+func openCertStore(u *uriAttributes) (windows.Handle, error) {
+	var certStoreLocation uint32
+	switch u.storeLocation {
+	case UserStoreLocation:
+		certStoreLocation = certStoreCurrentUser
+	case MachineStoreLocation:
+		certStoreLocation = certStoreLocalMachine
+	default:
+		return 0, fmt.Errorf("invalid cert store location %q", u.storeLocation)
+	}
+
+	// CertOpenStore takes the store name as a uintptr, so the conversion below
+	// leaves no Go pointer referring to the string: the garbage collector is
+	// free to reclaim it while the call is in flight. Hold it in a variable and
+	// keep it alive across the call. (The compiler's special case that makes
+	// this safe applies only to a conversion written inside a call to
+	// syscall.Syscall itself, which this is not.)
+	storeName := wide(u.storeName)
+	st, err := windows.CertOpenStore(
+		certStoreProvSystem,
+		0,
+		0,
+		certStoreLocation,
+		uintptr(unsafe.Pointer(storeName)),
+	)
+	runtime.KeepAlive(storeName)
+	if err != nil {
+		return 0, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+	}
+
+	return st, nil
+}
+
 // getCertContext returns a pointer to a X.509 certificate context based on the provided URI
 // callers are responsible for freeing the context
 func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error) {
@@ -413,26 +457,12 @@ func (k *CAPIKMS) getCertContext(u *uriAttributes) (*windows.CertContext, error)
 		return nil, fmt.Errorf("decoded %s has length %d; expected 20 bytes for SHA-1", HashArg, len(u.hash))
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return nil, fmt.Errorf("invalid cert store location %q", u.storeLocation)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))),
-	)
+	st, err := openCertStore(u)
 	if err != nil {
-		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+		return nil, err
 	}
+	// Safe to close while returning a context: see openCertStore.
+	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	// if issuer + any of the other fields in the list below is provided, then attempt a second certificate lookup when
 	// lookup by KeyID fails (not found).
@@ -865,26 +895,11 @@ func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, ra
 		return nil, fmt.Errorf("%q is required", IssuerNameArg)
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return nil, fmt.Errorf("invalid cert store location %q", u.storeLocation)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))),
-	)
+	st, err := openCertStore(u)
 	if err != nil {
-		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+		return nil, err
 	}
+	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	var (
 		certs    []*x509.Certificate
@@ -943,29 +958,10 @@ func (k *CAPIKMS) SearchCertificates(req *apiv1.SearchCertificatesRequest) (*api
 		return nil, err
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return nil, fmt.Errorf("invalid cert store location %q", u.storeLocation)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))),
-	)
+	st, err := openCertStore(u)
 	if err != nil {
-		return nil, fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+		return nil, err
 	}
-	// Unlike the other store-opening call sites in this file, SearchCertificates
-	// runs on every certificate issuance in long-running callers, so an
-	// unclosed store handle here is an unbounded leak rather than a one-off.
 	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	var (
@@ -1018,15 +1014,14 @@ func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 		return err
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return fmt.Errorf("invalid cert store location %q", u.storeLocation)
+	// Opened before the certificate context is built so an unusable store
+	// location fails before any key association work, which may prompt for a
+	// smart card.
+	st, err := openCertStore(u)
+	if err != nil {
+		return err
 	}
+	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	certContext, err := windows.CertCreateCertificateContext(
 		encodingX509ASN|encodingPKCS7,
@@ -1079,16 +1074,6 @@ func (k *CAPIKMS) StoreCertificate(req *apiv1.StoreCertificateRequest) error {
 
 	if u.description != "" {
 		cryptSetCertificateDescription(certContext, u.description)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))))
-	if err != nil {
-		return fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
 	}
 
 	// Add the cert context to the system certificate store
@@ -1175,25 +1160,13 @@ func (k *CAPIKMS) DeleteCertificate(req *apiv1.DeleteCertificateRequest) error {
 		return err
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return fmt.Errorf("invalid cert store location %q", u.storeLocation)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))))
+	st, err := openCertStore(u)
 	if err != nil {
-		return fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+		return err
 	}
+	// Safe to close while the delete paths below still hold a context: see
+	// openCertStore.
+	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	var certHandle *windows.CertContext
 
@@ -1329,26 +1302,11 @@ func (k *CAPIKMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error
 		return fmt.Errorf("%q is required", IssuerNameArg)
 	}
 
-	var certStoreLocation uint32
-	switch u.storeLocation {
-	case UserStoreLocation:
-		certStoreLocation = certStoreCurrentUser
-	case MachineStoreLocation:
-		certStoreLocation = certStoreLocalMachine
-	default:
-		return fmt.Errorf("invalid cert store location %q", u.storeLocation)
-	}
-
-	st, err := windows.CertOpenStore(
-		certStoreProvSystem,
-		0,
-		0,
-		certStoreLocation,
-		uintptr(unsafe.Pointer(wide(u.storeName))),
-	)
+	st, err := openCertStore(u)
 	if err != nil {
-		return fmt.Errorf("CertOpenStore for the %q store %q returned: %w", u.storeLocation, u.storeName, err)
+		return err
 	}
+	defer func() { _ = windows.CertCloseStore(st, 0) }()
 
 	now := time.Now()
 	var errs []error

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -926,8 +926,10 @@ func (k *CAPIKMS) FindCertificatesByIssuer(req *apiv1.LoadCertificateRequest, ra
 // certificate, reads the CNG/CAPI key container recorded in its
 // CERT_KEY_PROV_INFO property. It never opens a key handle, so a certificate
 // whose associated key no longer exists is still returned, with its recorded
-// container name; a certificate is skipped when its properties cannot be read
-// at all, or when its DER encoding cannot be parsed.
+// container name. A certificate whose key-provider metadata cannot be read is
+// returned too, with the failure recorded on the result's Err field; only a
+// certificate whose DER encoding cannot be parsed is skipped, there being no
+// certificate to report.
 func (k *CAPIKMS) SearchCertificates(req *apiv1.SearchCertificatesRequest) (*apiv1.SearchCertificatesResponse, error) {
 	if req == nil {
 		return nil, errors.New("searchCertificatesRequest cannot be nil")
@@ -994,14 +996,16 @@ func (k *CAPIKMS) SearchCertificates(req *apiv1.SearchCertificatesRequest) (*api
 			continue
 		}
 
+		// A certificate with no key association at all reads back as ("", nil),
+		// so an error here means the association exists but could not be
+		// interpreted — precisely the kind of broken credential a caller
+		// sweeping the store is looking for. Report it on the result instead of
+		// dropping the certificate.
 		containerName, err := cryptFindCertificateKeyContainerName(certHandle)
-		if err != nil {
-			continue
-		}
-
 		results = append(results, apiv1.SearchCertificateResult{
 			Certificate:      x509Cert,
 			KeyContainerName: containerName,
+			Err:              err,
 		})
 	}
 

--- a/kms/capi/capi.go
+++ b/kms/capi/capi.go
@@ -970,19 +970,17 @@ func (k *CAPIKMS) SearchCertificates(req *apiv1.SearchCertificatesRequest) (*api
 		enumErr  error
 	)
 	for {
+		// CertEnumCertificatesInStore returns a nil context, and so a non-nil
+		// error, both at the end of the store and on failure; either way it has
+		// already freed prevCert.
 		certHandle, err := windows.CertEnumCertificatesInStore(st, prevCert)
 		if err != nil {
-			if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
-				// End of store; prevCert was freed by this call per the Windows API contract.
-				break
+			if isNotFound(err) {
+				break // end of store
 			}
-			// A real enumeration failure: prevCert was still freed by this call, but
-			// the store may hold unvisited certificates, so what we have is partial.
+			// A real enumeration failure: the store may hold unvisited
+			// certificates, so what we have is partial.
 			enumErr = fmt.Errorf("CertEnumCertificatesInStore failed: %w", err)
-			break
-		}
-		if certHandle == nil {
-			// prevCert was freed by this call per the Windows API contract.
 			break
 		}
 		prevCert = certHandle // freed on next CertEnumCertificatesInStore call

--- a/kms/capi/capi_windows_test.go
+++ b/kms/capi/capi_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"math/big"
 	"testing"
 	"time"
@@ -20,11 +21,13 @@ import (
 	"go.step.sm/crypto/kms/apiv1"
 )
 
-// TestCAPIKMS_SearchCertificates_user runs only on a developer Windows
-// machine: crypto's CI has no Windows runner, so this test is not executed
-// there. It exercises the current-user "My" store, which does not require
-// administrative rights.
-func TestCAPIKMS_SearchCertificates_user(t *testing.T) {
+// mustStoreSelfSignedCertificate generates a self-signed certificate, stores it
+// in the current-user "My" store using the given URI, and registers its removal
+// with t.Cleanup. storeName carries the attributes under test; the certificate
+// is always deleted by SHA-1 fingerprint.
+func mustStoreSelfSignedCertificate(t *testing.T, k *CAPIKMS, storeName string) *x509.Certificate {
+	t.Helper()
+
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -50,11 +53,6 @@ func TestCAPIKMS_SearchCertificates_user(t *testing.T) {
 	require.NoError(t, err)
 	deleteName := "capi:store-location=user;store=My;sha1=" + fp
 
-	k := &CAPIKMS{}
-
-	// skip-find-certificate-key=true stores the certificate with no
-	// associated private key, matching the case being asserted below.
-	storeName := "capi:store-location=user;store=My;skip-find-certificate-key=true"
 	require.NoError(t, k.StoreCertificate(&apiv1.StoreCertificateRequest{
 		Name:        storeName,
 		Certificate: cert,
@@ -63,19 +61,73 @@ func TestCAPIKMS_SearchCertificates_user(t *testing.T) {
 		assert.NoError(t, k.DeleteCertificate(&apiv1.DeleteCertificateRequest{Name: deleteName}))
 	})
 
+	return cert
+}
+
+// findSearchResult returns the SearchCertificates result matching cert, or nil.
+func findSearchResult(resp *apiv1.SearchCertificatesResponse, cert *x509.Certificate) *apiv1.SearchCertificateResult {
+	for i := range resp.Results {
+		if resp.Results[i].Certificate.SerialNumber.Cmp(cert.SerialNumber) == 0 {
+			return &resp.Results[i]
+		}
+	}
+	return nil
+}
+
+// TestCAPIKMS_SearchCertificates_user runs only on a developer Windows
+// machine: crypto's CI has no Windows runner, so this test is not executed
+// there. It exercises the current-user "My" store, which does not require
+// administrative rights.
+func TestCAPIKMS_SearchCertificates_user(t *testing.T) {
+	k := &CAPIKMS{}
+
+	// skip-find-certificate-key=true stores the certificate with no
+	// associated private key, matching the case being asserted below.
+	cert := mustStoreSelfSignedCertificate(t, k,
+		"capi:store-location=user;store=My;skip-find-certificate-key=true")
+
 	resp, err := k.SearchCertificates(&apiv1.SearchCertificatesRequest{
 		Name: "capi:store-location=user;store=My",
 	})
 	require.NoError(t, err)
 
-	var found *apiv1.SearchCertificateResult
-	for i := range resp.Results {
-		if resp.Results[i].Certificate.SerialNumber.Cmp(cert.SerialNumber) == 0 {
-			found = &resp.Results[i]
-			break
-		}
-	}
+	found := findSearchResult(resp, cert)
 	require.NotNil(t, found, "stored certificate not returned by SearchCertificates")
 	assert.Equal(t, cert.Raw, found.Certificate.Raw)
 	assert.Empty(t, found.KeyContainerName)
+	assert.NoError(t, found.Err)
+}
+
+// TestCAPIKMS_SearchCertificates_keyContainerName asserts the container name
+// recorded on a certificate is read back verbatim. It is the counterpart to
+// TestCAPIKMS_SearchCertificates_user, which asserts the no-association case
+// and so cannot distinguish a working reader from one that returns "" for
+// everything.
+//
+// No key is created: StoreCertificate's "key" branch records the association
+// with setCertificateKeyProvInfo without verifying the container exists, which
+// produces exactly the state this API exists to detect — a certificate naming a
+// key container that is not there. That also means this test needs no TPM and
+// no administrative rights, only Windows.
+func TestCAPIKMS_SearchCertificates_keyContainerName(t *testing.T) {
+	k := &CAPIKMS{}
+
+	suffix := make([]byte, 8)
+	_, err := rand.Read(suffix)
+	require.NoError(t, err)
+	containerName := "go-step-crypto-test-" + hex.EncodeToString(suffix)
+
+	cert := mustStoreSelfSignedCertificate(t, k,
+		"capi:store-location=user;store=My;key="+containerName+";skip-find-certificate-key=true")
+
+	resp, err := k.SearchCertificates(&apiv1.SearchCertificatesRequest{
+		Name: "capi:store-location=user;store=My",
+	})
+	require.NoError(t, err)
+
+	found := findSearchResult(resp, cert)
+	require.NotNil(t, found, "stored certificate not returned by SearchCertificates")
+	assert.Equal(t, cert.Raw, found.Certificate.Raw)
+	assert.NoError(t, found.Err)
+	assert.Equal(t, containerName, found.KeyContainerName)
 }

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -241,6 +241,14 @@ func errNoToStr(e uint32) string {
 	}
 }
 
+// isNotFound reports whether err is the CRYPT_E_NOT_FOUND status CryptoAPI
+// returns when a certificate or a certificate property simply is not there, as
+// opposed to a failure to look for it.
+func isNotFound(err error) bool {
+	var errno windows.Errno
+	return errors.As(err, &errno) && uint32(errno) == CRYPT_E_NOT_FOUND
+}
+
 // wide returns a pointer to a uint16 representing the equivalent
 // to a Windows LPCWSTR.
 func wide(s string) *uint16 {
@@ -579,7 +587,7 @@ func findCertificateInStore(store windows.Handle, enc, findFlags, findType uint3
 	)
 	if h == 0 {
 		// Actual error, or simply not found?
-		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+		if isNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -675,7 +683,7 @@ func cryptFindCertificateKeyContainerName(certContext *windows.CertContext) (str
 
 	err := certGetCertificateContextProperty(certContext, CERT_KEY_PROV_INFO_PROP_ID, nil, &size)
 	if err != nil {
-		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+		if isNotFound(err) {
 			return "", nil
 		}
 		return "", err
@@ -776,7 +784,7 @@ func cryptFindCertificateFriendlyName(certContext *windows.CertContext) (string,
 
 	err := certGetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, nil, &size)
 	if err != nil {
-		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+		if isNotFound(err) {
 			return "", nil
 		}
 
@@ -802,7 +810,7 @@ func cryptFindCertificateDescription(certContext *windows.CertContext) (string, 
 
 	err := certGetCertificateContextProperty(certContext, CERT_DESCRIPTION_PROP_ID, nil, &size)
 	if err != nil {
-		if errno, ok := err.(windows.Errno); ok && uint32(errno) == CRYPT_E_NOT_FOUND {
+		if isNotFound(err) {
 			return "", nil
 		}
 

--- a/kms/capi/ncrypt_windows.go
+++ b/kms/capi/ncrypt_windows.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -693,17 +692,38 @@ func cryptFindCertificateKeyContainerName(certContext *windows.CertContext) (str
 
 	info := (*CRYPT_KEY_PROV_INFO)(unsafe.Pointer(&buf[0]))
 
-	// info.pwszContainerName is an interior pointer into buf, and buf is a
-	// []byte the garbage collector treats as pointer-free (it never scans it
-	// for references), so nothing keeps buf alive once info is read. Without
-	// runtime.KeepAlive, buf could be collected while UTF16PtrToString is
-	// still walking the UTF-16 string through info.pwszContainerName. This
-	// differs from setCertificateKeyProvInfo's write path, where the Win32
-	// call itself copies the string before returning, so no such window
-	// exists there.
-	name := windows.UTF16PtrToString(info.pwszContainerName)
-	runtime.KeepAlive(buf)
-	return name, nil
+	return utf16StringInBuffer(buf, info.pwszContainerName)
+}
+
+// utf16StringInBuffer decodes the NUL-terminated UTF-16 string p points at,
+// reading it out of buf rather than dereferencing p. CryptoAPI returns
+// properties such as CERT_KEY_PROV_INFO as a self-contained blob: the string
+// members point at bytes appended after the struct, inside the buffer the
+// caller supplied. Going through buf keeps every read bounds-checked against
+// the size the API reported, and keeps the backing array reachable while it is
+// being read, so the decoded string never outlives what it was decoded from.
+func utf16StringInBuffer(buf []byte, p *uint16) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+
+	off := uintptr(unsafe.Pointer(p)) - uintptr(unsafe.Pointer(&buf[0]))
+	if off >= uintptr(len(buf)) || off%2 != 0 {
+		// A pointer before buf underflows to a very large offset, so this one
+		// check rejects both directions.
+		return "", errors.New("string does not point into the property buffer")
+	}
+
+	s := make([]uint16, 0, (uintptr(len(buf))-off)/2)
+	for i := off; i+1 < uintptr(len(buf)); i += 2 {
+		c := binary.LittleEndian.Uint16(buf[i:])
+		if c == 0 {
+			return windows.UTF16ToString(s), nil
+		}
+		s = append(s, c)
+	}
+
+	return "", errors.New("unterminated string in the property buffer")
 }
 
 func certSetCertificateContextProperty(certContext *windows.CertContext, propID uint32, pvData uintptr) error {

--- a/kms/platform/kms.go
+++ b/kms/platform/kms.go
@@ -339,6 +339,10 @@ func (k *KMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
 // returned unmodified alongside the error, so callers wanting the partial
 // results must check the response before the error.
 func (k *KMS) SearchCertificates(req *apiv1.SearchCertificatesRequest) (*apiv1.SearchCertificatesResponse, error) {
+	if req == nil {
+		return nil, errors.New("searchCertificatesRequest cannot be nil")
+	}
+
 	km, ok := k.backend.(apiv1.CertificateSearcher)
 	if !ok {
 		return nil, apiv1.NotImplementedError{}

--- a/kms/platform/kms.go
+++ b/kms/platform/kms.go
@@ -330,7 +330,8 @@ func (k *KMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error {
 // the backend's URI scheme before delegating, the same way CleanupCredentials
 // translates its request name. The response carries only certificates and a
 // key-container name, neither of which encodes a KMS URI, so no response
-// translation is needed.
+// translation is needed. Per-certificate metadata failures reported on a
+// result's Err field are passed through untouched as well.
 //
 // SearchCertificates is best-effort: on a mid-enumeration failure the backend
 // may return a non-nil response holding the certificates enumerated before

--- a/kms/platform/kms_test.go
+++ b/kms/platform/kms_test.go
@@ -1356,6 +1356,9 @@ func TestKMS_SearchCertificates(t *testing.T) {
 		}}, func(tt assert.TestingT, err error, i ...interface{}) bool {
 			return assert.ErrorIs(tt, err, apiv1.NotImplementedError{})
 		}},
+		// A nil request must be rejected rather than panic in clone(req),
+		// whichever backend is configured.
+		{"nil request", softKMS, args{nil}, assert.Error},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -1194,7 +1194,9 @@ func (k *TPMKMS) CleanupCredentials(req *apiv1.CleanupCredentialsRequest) error 
 // returned response may still be non-nil and hold the certificates
 // enumerated before the failure, together with a non-nil error describing
 // what went wrong. Callers wanting those partial results must check the
-// response before (or regardless of) the error.
+// response before (or regardless of) the error. A certificate whose key
+// metadata could not be read is reported with that failure on its result's Err
+// field rather than dropped.
 //
 // The platform wrapper's URI transform unconditionally injects
 // "skip-find-certificate-key=true" into every Windows request, including


### PR DESCRIPTION
Stacked on #1089 — review that one first; this PR's diff is against it, not against master.

Six follow-ups from review of #1089. They either change behavior that PR deliberately scoped out, or touch pre-existing code, so they are kept separate.

## The container name reader no longer follows a raw pointer

`cryptFindCertificateKeyContainerName` dereferenced the `pwszContainerName` pointer CryptoAPI wrote into the property buffer, walking UTF-16 until a NUL with no relation to the size the API reported, and pinned the buffer with `runtime.KeepAlive`.

The `KeepAlive` was a no-op. Go's GC retains an object when any pointer *into* it is live, and both `info` and `info.pwszContainerName` are interior pointers into `buf`. Noscan means the collector doesn't scan *inside* `buf` for outgoing pointers; it says nothing about incoming references. The comment justifying the `KeepAlive` asserted the opposite, which is the kind of reasoning that gets copied to somewhere it matters.

The hazard that was real is the unbounded read. The string is now decoded out of `buf`, so every read is bounds-checked against the reported size and a short or malformed property returns an error instead of reading past the buffer. The new `utf16StringInBuffer` helper is reusable for `pwszProvName`.

## Certificates with unreadable key metadata are reported, not hidden

`SearchCertificates` dropped a certificate whenever its `CERT_KEY_PROV_INFO` couldn't be read. A certificate with no private-key association already reads back as `("", nil)` via `CRYPT_E_NOT_FOUND`, so the only ones reaching that path had an association that exists but is corrupt — exactly the population this API was added to find.

`apiv1.SearchCertificateResult` gains an `Err` field carrying the read failure. That also lets a caller tell "no key association at all" apart from "association present but unreadable". A certificate whose DER can't be parsed is still skipped; there's no certificate to report.

## A test that actually pins the fix

The capi test in #1089 stores with `skip-find-certificate-key=true` and asserts the container name comes back **empty** — it passes just as happily against the reader #1089 replaced, which returned `""` unconditionally. The only assertion of a real container name needs both a TPM and Windows.

The new capi test pins the name on any Windows box. `StoreCertificate`'s `key=` branch records the association via `setCertificateKeyProvInfo` without checking the container exists, so no key, no TPM and no administrative rights are needed — and it sets up precisely the state this feature exists to detect: a certificate naming a key container that isn't there.

## Certificate store handles are closed

Six functions opened a store with the same twenty lines of location switch, `CertOpenStore` and error wrap; five never closed the handle. `SearchCertificates` was the exception, on the grounds that a search invites frequent calls — but `FindCertificatesByIssuer` and `CleanupCredentials` are called just as often by the same sweeps, and every `LoadCertificate`, `CreateSigner` and `GetPublicKey` leaked one through `getCertContext`.

Extracted `openCertStore` and closed the handle at all six. Closing with no flags only drops a reference — a certificate context holds its own — so `getCertContext` can close with a `defer` while still handing a live context back. `CERT_CLOSE_STORE_FORCE_FLAG` would not be safe there and is deliberately not used.

Consolidating also fixed a latent GC hazard all six copies shared: the store name was converted to `uintptr` inside the call, leaving no Go pointer to it, so it could be reclaimed while `CertOpenStore` ran. The compiler's special case for that pattern covers only conversions written inside a `syscall.Syscall` call, which this isn't. It's now held in a variable and kept alive across the call — the genuine version of the pattern the first commit removes, and the two comments explain the difference.

`StoreCertificate` opens its store before building the certificate context, preserving the early store-location validation so an unusable location still fails before key association, which can prompt for a smart card.

## Smaller fixes

- Five bare `err.(windows.Errno)` assertions replaced with an `isNotFound` helper built on `errors.As`, which keeps working when the error arrives wrapped.
- Removed the `certHandle == nil` branch in `SearchCertificates`. x/sys sets `err` whenever `CertEnumCertificatesInStore` returns a nil context (`errnoErr` maps a zero errno to `EINVAL`, not nil), so it was unreachable, and its presence implied the two conditions were independent.
- `platform.KMS.SearchCertificates` rejects a nil request instead of panicking in `clone(req)`. `capi` and `tpmkms` keep their own checks — both are exported backends used directly too. `platform.CleanupCredentials` has the same gap, left alone here.

## Verification

CI here is ubuntu-only, so none of the windows-tagged code runs there. Stating exactly what was run locally:

- `GOOS=windows GOARCH=amd64 go build ./kms/...` — clean, and clean at each of the six commits individually
- `GOOS=windows GOARCH=amd64 go vet ./kms/capi/... ./kms/platform/... ./kms/tpmkms/...` — the single finding (`ncrypt_windows.go` `possible misuse of unsafe.Pointer` in `findCertificateInStore`) is byte-identical to the base branch; only its line number moved. Nothing new around the `uintptr` arithmetic in `utf16StringInBuffer`.
- `go test ./kms/...` on the host; windows-tagged tests compile under `GOOS=windows`
- `utf16StringInBuffer` was validated against a synthetic blob laid out the way CryptoAPI lays one out: correct container and provider names, out-of-buffer pointer rejected (an underflowing offset wraps to a huge `uintptr`, so one check covers both directions), unterminated string rejected
- `golangci-lint` could **not** be run locally: the shared smallstep config requires a newer version than 2.4.0, and once patched around that the linter panics type-checking a dependency needing go1.26 while built with go1.25. It fails identically on the base branch, so it's a local toolchain gap rather than something this branch introduces — CI covers it.

Still outstanding, not addressed here: the `KeyContainerName` field is a CAPI/CNG concept sitting in cross-platform `apiv1`, and unlike `SearchKeys` it returns a raw container name rather than a KMS URI the platform wrapper can translate. Worth settling while the interface is still Experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)