### PR TITLE
tpmkms: only claim a Windows certificate's key when the key is ours

### DIFF
--- a/kms/tpmkms/tpmkms.go
+++ b/kms/tpmkms/tpmkms.go
@@ -1060,6 +1060,20 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 	// prefixed with "app-" (see prefixKey / go-attestation), which is how the
 	// key was persisted in the PCP KSP. CAPI resolves the keyset from key-scope,
 	// falling back to store-location when key-scope is unset.
+	//
+	// Only for a key this TPMKMS actually holds, though. A caller may name a key
+	// that is not a TPM key at all — a Windows endpoint with no key protection
+	// has its key created through CAPI in the software KSP, under the bare name,
+	// and this store has never heard of it. Claiming such a certificate lives in
+	// "app-<name>" under the Platform Crypto Provider names a container that
+	// does not exist: the certificate then reports HasPrivateKey while resolving
+	// no key at all, so it cannot complete a handshake and cannot be found again
+	// by a lookup that goes through the key.
+	//
+	// The non-Windows branch of StoreCertificateChain already resolves the key
+	// before storing; this makes the Windows branch agree, and falls back to
+	// discovery — what every caller had before the explicit binding — when the
+	// name is not ours.
 	v := url.Values{
 		"store-location":              []string{location},
 		"store":                       []string{store},
@@ -1069,12 +1083,28 @@ func (k *TPMKMS) storeCertificateChainToWindowsCertificateStore(req *apiv1.Store
 		"intermediate-store-location": []string{intermediateCAStoreLocation},
 		"intermediate-store":          []string{intermediateCAStore},
 	}
-	if o.name != "" {
+	switch {
+	case o.name == "":
+	case k.managesKey(o.name):
 		v.Set("key", tpm.ApplicationKeyName(o.name))
 		v.Set("provider", microsoftPCP)
 		if o.keyScope != "" {
 			v.Set("key-scope", o.keyScope)
 		}
+	default:
+		// Named a key this TPM does not hold, so let CAPI find it. Discovery is
+		// re-enabled here specifically, overriding the blanket
+		// skip-find-certificate-key the platform wrapper injects into every
+		// Windows request: that exists to avoid a smart-card prompt while
+		// looking for a TPM key discovery cannot find anyway, and neither half
+		// of that reasoning applies to a key held by another provider.
+		//
+		// Without this the certificate is stored with no key association at
+		// all, which is how a non-attested endpoint's certificate behaved
+		// between the skip being introduced and the explicit binding being
+		// added. CAPI restricts the search to the keyset the store location
+		// implies, so this does not widen it.
+		v.Set("skip-find-certificate-key", "false")
 	}
 
 	return k.windowsCertificateManager.StoreCertificateChain(&apiv1.StoreCertificateChainRequest{
@@ -1897,6 +1927,19 @@ func (k *TPMKMS) getAK(ctx context.Context, name string) (*tpm.AK, error) {
 		return nil, notFoundError(err)
 	}
 	return ak, nil
+}
+
+// managesKey reports whether name identifies a key held by this TPM.
+//
+// Only a definitive "no" is treated as one. A lookup that fails for any other
+// reason — the TPM busy, unavailable, or unreadable under the current identity
+// — leaves the answer unknown, and the caller keeps the explicit association it
+// would otherwise have made. Guessing "not ours" there would drop the binding
+// for a genuine TPM key and reintroduce the machine-scoped discovery failure
+// the explicit association exists to avoid.
+func (k *TPMKMS) managesKey(name string) bool {
+	_, err := k.tpm.GetKey(context.Background(), name)
+	return !errors.Is(err, tpm.ErrNotFound)
 }
 
 func (k *TPMKMS) getKey(ctx context.Context, name string) (*tpm.Key, error) {

--- a/kms/tpmkms/tpmkms_simulator_test.go
+++ b/kms/tpmkms/tpmkms_simulator_test.go
@@ -2796,3 +2796,25 @@ func TestTPMKMS_CleanupCredentials_keyEnumerationDegraded(t *testing.T) {
 		assert.Contains(t, err.Error(), "fall back to direct key deletion")
 	})
 }
+
+// A certificate is only bound to an "app-<name>" Platform Crypto Provider
+// container when the name really is one of this TPM's keys. A caller can name a
+// key created elsewhere -- on Windows an endpoint with no key protection has its
+// key made through CAPI in the software KSP, under the bare name -- and binding
+// that certificate to a PCP container names one that does not exist, leaving a
+// certificate that reports HasPrivateKey while resolving no key at all.
+func TestTPMKMS_managesKey(t *testing.T) {
+	tpm := newSimulatedTPM(t)
+	kms := &TPMKMS{tpm: tpm}
+
+	_, err := kms.CreateKey(&apiv1.CreateKeyRequest{
+		Name:               "tpmkms:name=ownkey",
+		SignatureAlgorithm: apiv1.ECDSAWithSHA256,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, kms.managesKey("ownkey"),
+		"a key this TPM created must keep its explicit association")
+	assert.False(t, kms.managesKey("madeelsewhere"),
+		"a name this TPM has never held must fall back to discovery instead of claiming a PCP container")
+}


### PR DESCRIPTION
**Draft** — opened for review of the approach and for CI, while the downstream agent change that depends on it is validated.

## The problem

`storeCertificateChainToWindowsCertificateStore` associates every certificate it stores with `app-<name>` under the Microsoft Platform Crypto Provider, unconditionally:

```go
v.Set("key", tpm.ApplicationKeyName(o.name))
v.Set("provider", microsoftPCP)
```

A caller can name a key that is not a TPM key. On Windows that is exactly what a smallstep agent endpoint with `KeyProtection_NONE` looks like: its key is created through CAPI in the **software KSP** under the bare endpoint name, while its certificate is stored through this KMS. The association then names a container that does not exist.

The resulting certificate:

- reports `HasPrivateKey=True` and appears in the browser's client-certificate picker
- resolves **no** key, so it cannot complete a handshake
- is unreachable by any lookup that goes through the key — so replace-on-store never replaces, and certificates accumulate

## History

Three stages, which is why this went unnoticed:

| when | association | symptom |
|---|---|---|
| before 2026-02-25 | discovery → correct | worked |
| 2026-02-25 (`ead241c`/`3131fc6`) | platform injects `skip-find-certificate-key=true` → **none** | `HasPrivateKey=False`, absent from the picker |
| 2026-06-11 (`d1a37b0`) | explicit `app-<name>` + PCP → **wrong** | `HasPrivateKey=True`, in the picker, fails at handshake |

`d1a37b0` fixed machine-scoped TPM association and, as collateral, made an already-broken certificate look healthy. Shipped since v0.83.0.

## The change

Three-way instead of unconditional:

- **key this TPM holds** → explicit binding, unchanged. What `d1a37b0` fixed stays fixed.
- **key it does not hold** → drop the binding *and* re-enable discovery for that store. The platform wrapper's blanket `skip-find-certificate-key=true` exists to avoid a smart-card prompt while hunting for a TPM key discovery cannot find anyway; neither half of that reasoning applies to a key another provider holds. Without re-enabling it the certificate gets no association at all — still unusable, just invisible rather than misleading. CAPI restricts the search to the keyset the store location implies, so this does not widen it.
- **no name** → unchanged.

`managesKey` treats only a definitive `ErrNotFound` as "not ours". A lookup that fails because the TPM is busy or unreadable leaves the answer unknown and keeps the association, so a transient fault cannot silently drop the binding for a genuine TPM key.

## Verification

Simulator test covering both branches of `managesKey`. `go test ./...` and the `tpmsimulator`-tagged suites pass.

Verified on a real Windows host by reproducing the agent's path — software-KSP key created through CAPI, certificate stored through this KMS — and reading back the recorded container:

```
before:  recorded container = "app-bindtest"   (does not exist)
after:   recorded container = "bindtest"       (holds the key)
```

## Review notes

The riskiest part is re-enabling discovery, since the skip was added deliberately. It applies only on the path where the named key is provably not a TPM key, which is a path that previously produced an unusable certificate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)