### PR TITLE
Fix pkcs11 tests on macOS

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/ThalesGroup/crypto11"
@@ -301,8 +302,8 @@ func (k *PKCS11) DeleteKey(u string) error {
 	if err != nil {
 		return errors.Wrap(err, "deleteKey failed")
 	}
-	signer, err := k.p11.FindKeyPair(id, object)
-	if err != nil {
+	signer, err := findKeyPair(k.p11, id, object)
+	if err != nil && !errors.Is(err, apiv1.NotFoundError{}) {
 		return errors.Wrap(err, "deleteKey failed")
 	}
 	if signer == nil {
@@ -361,8 +362,8 @@ func generateKey(ctx P11, req *apiv1.CreateKeyRequest) (crypto11.Signer, error) 
 		return nil, err
 	}
 
-	signer, err := ctx.FindKeyPair(id, object)
-	if err != nil {
+	signer, err := findKeyPair(ctx, id, object)
+	if err != nil && !errors.Is(err, apiv1.NotFoundError{}) {
 		return nil, err
 	}
 	if signer != nil {
@@ -414,14 +415,27 @@ func generateKey(ctx P11, req *apiv1.CreateKeyRequest) (crypto11.Signer, error) 
 	}
 }
 
+func findKeyPair(ctx P11, id, label []byte) (crypto11.Signer, error) {
+	signer, err := ctx.FindKeyPair(id, label)
+	if err != nil {
+		if strings.Contains(err.Error(), "was not found") {
+			return nil, apiv1.NotFoundError{
+				Message: err.Error(),
+			}
+		}
+		return nil, err
+	}
+	return signer, nil
+}
+
 func findSigner(ctx P11, rawuri string) (crypto11.Signer, error) {
 	id, object, err := parseObject(rawuri)
 	if err != nil {
 		return nil, err
 	}
-	signer, err := ctx.FindKeyPair(id, object)
+	signer, err := findKeyPair(ctx, id, object)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error finding key with uri %s", rawuri)
+		return nil, err
 	}
 	if signer == nil {
 		return nil, errors.Errorf("key with uri %s not found", rawuri)

--- a/kms/pkcs11/setup_test.go
+++ b/kms/pkcs11/setup_test.go
@@ -84,7 +84,7 @@ func setup(t TBTesting, k *PKCS11) {
 		if err != nil && !errors.Is(errors.Cause(err), apiv1.AlreadyExistsError{
 			Message: tk.Name + " already exists",
 		}) {
-			t.Errorf("PKCS11.GetPublicKey() error = %v", err)
+			t.Errorf("PKCS11.CreateKey() error = %v", err)
 		}
 	}
 

--- a/kms/pkcs11/softhsm2_test.go
+++ b/kms/pkcs11/softhsm2_test.go
@@ -3,6 +3,7 @@
 package pkcs11
 
 import (
+	"os"
 	"runtime"
 	"sync"
 
@@ -24,19 +25,35 @@ var softHSM2Once sync.Once
 func mustPKCS11(t TBTesting) *PKCS11 {
 	t.Helper()
 	testModule = "SoftHSM2"
-	if runtime.GOARCH != "amd64" {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Fatalf("softHSM2 test skipped on %s:%s", runtime.GOOS, runtime.GOARCH)
 	}
 
-	var path string
+	var paths []string
 	switch runtime.GOOS {
 	case "darwin":
-		path = "/usr/local/lib/softhsm/libsofthsm2.so"
+		paths = []string{
+			"/usr/local/lib/softhsm/libsofthsm2.so",
+			"/opt/homebrew/lib/softhsm/libsofthsm2.so",
+		}
 	case "linux":
-		path = "/usr/lib/softhsm/libsofthsm2.so"
+		paths = []string{
+			"/usr/lib/softhsm/libsofthsm2.so",
+		}
 	default:
 		t.Skipf("softHSM2 test skipped on %s", runtime.GOOS)
 		return nil
+	}
+
+	var path string
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			path = p
+			break
+		}
+	}
+	if path == "" {
+		t.Skipf("softHSM2 test skipped on %s: libsofthsm2.so not found", runtime.GOOS)
 	}
 	p11, err := crypto11.Configure(&crypto11.Config{
 		Path:       path,


### PR DESCRIPTION
This commit updates the softhsm2 paths on macOS to support new homebrew paths.

This also fixes the FindKeyPair so it works the same way it used to work on previous versions of crypto11.